### PR TITLE
[Feature] Support FP16 mixed-precision training

### DIFF
--- a/configs/styleganv2/stylegan2_c2_apex_fp16_quicktest_ffhq_256_b4x8_800k.py
+++ b/configs/styleganv2/stylegan2_c2_apex_fp16_quicktest_ffhq_256_b4x8_800k.py
@@ -4,9 +4,9 @@ _base_ = ['./stylegan2_c2_ffhq_256_b4x8_800k.py']
 
 model = dict(
     generator=dict(out_size=256),
-    discriminator=dict(in_size=256),
-    disc_auxiliary_loss=dict(use_apex_amp=True),
-    gen_auxiliary_loss=dict(use_apex_amp=True),
+    discriminator=dict(in_size=256, convert_input_fp32=False),
+    # disc_auxiliary_loss=dict(use_apex_amp=True),
+    # gen_auxiliary_loss=dict(use_apex_amp=True),
 )
 
 dataset_type = 'QuickTestImageDataset'

--- a/configs/styleganv2/stylegan2_c2_apex_fp16_quicktest_ffhq_256_b4x8_800k.py
+++ b/configs/styleganv2/stylegan2_c2_apex_fp16_quicktest_ffhq_256_b4x8_800k.py
@@ -1,0 +1,30 @@
+"""Config for the `config-f` setting in StyleGAN2."""
+
+_base_ = ['./stylegan2_c2_ffhq_256_b4x8_800k.py']
+
+model = dict(
+    generator=dict(out_size=256),
+    discriminator=dict(in_size=256),
+    disc_auxiliary_loss=dict(use_apex_amp=True),
+    gen_auxiliary_loss=dict(use_apex_amp=True),
+)
+
+dataset_type = 'QuickTestImageDataset'
+data = dict(
+    samples_per_gpu=2,
+    train=dict(type=dataset_type, size=(256, 256)),
+    val=dict(type=dataset_type, size=(256, 256)))
+
+log_config = dict(interval=1)
+
+total_iters = 800002
+
+apex_amp = dict(
+    mode='gan', init_args=dict(opt_level='O1', num_losses=2, loss_scale=512.))
+
+evaluation = dict(
+    type='GenerativeEvalHook',
+    interval=10000,
+    metrics=dict(
+        type='FID', num_images=50000, inception_pkl=None, bgr2rgb=True),
+    sample_kwargs=dict(sample_model='ema'))

--- a/configs/styleganv2/stylegan2_c2_fp16-global_quicktest_ffhq_256_b4x8_800k.py
+++ b/configs/styleganv2/stylegan2_c2_fp16-global_quicktest_ffhq_256_b4x8_800k.py
@@ -3,8 +3,8 @@
 _base_ = ['./stylegan2_c2_ffhq_256_b4x8_800k.py']
 
 model = dict(
-    generator=dict(out_size=256, num_fp16_scales=4),
-    discriminator=dict(in_size=256, num_fp16_scales=4),
+    generator=dict(out_size=256, fp16_enabled=True),
+    discriminator=dict(in_size=256, fp16_enabled=True),
     disc_auxiliary_loss=dict(data_info=dict(loss_scaler='loss_scaler')),
     # gen_auxiliary_loss=dict(data_info=dict(loss_scaler='loss_scaler')),
 )

--- a/configs/styleganv2/stylegan2_c2_fp16_quicktest_ffhq_256_b4x8_800k.py
+++ b/configs/styleganv2/stylegan2_c2_fp16_quicktest_ffhq_256_b4x8_800k.py
@@ -1,0 +1,29 @@
+"""Config for the `config-f` setting in StyleGAN2."""
+
+_base_ = ['./stylegan2_c2_ffhq_256_b4x8_800k.py']
+
+model = dict(
+    generator=dict(out_size=256, num_fp16_scales=4),
+    discriminator=dict(in_size=256, num_fp16_scales=4),
+    disc_auxiliary_loss=dict(data_info=dict(loss_scaler='loss_scaler')),
+    gen_auxiliary_loss=dict(data_info=dict(loss_scaler='loss_scaler')),
+)
+
+dataset_type = 'QuickTestImageDataset'
+data = dict(
+    samples_per_gpu=1,
+    train=dict(type=dataset_type, size=(256, 256)),
+    val=dict(type=dataset_type, size=(256, 256)))
+
+log_config = dict(interval=1)
+
+total_iters = 800002
+
+runner = dict(fp16_loss_scaler=dict())
+
+evaluation = dict(
+    type='GenerativeEvalHook',
+    interval=10000,
+    metrics=dict(
+        type='FID', num_images=50000, inception_pkl=None, bgr2rgb=True),
+    sample_kwargs=dict(sample_model='ema'))

--- a/configs/styleganv2/stylegan2_c2_fp16_quicktest_ffhq_256_b4x8_800k.py
+++ b/configs/styleganv2/stylegan2_c2_fp16_quicktest_ffhq_256_b4x8_800k.py
@@ -11,7 +11,7 @@ model = dict(
 
 dataset_type = 'QuickTestImageDataset'
 data = dict(
-    samples_per_gpu=1,
+    samples_per_gpu=2,
     train=dict(type=dataset_type, size=(256, 256)),
     val=dict(type=dataset_type, size=(256, 256)))
 

--- a/mmgen/apis/train.py
+++ b/mmgen/apis/train.py
@@ -58,7 +58,12 @@ def train_model(model,
     ]
 
     # dirty code for use apex amp
-    model = model.cuda()
+    # apex.amp request that models should be in cuda device before
+    # initialization.
+    if cfg.get('apex_amp', None):
+        assert distributed, (
+            'Currently, apex.amp is only supported with DDP training.')
+        model = model.cuda()
 
     # build optimizer
     if cfg.optimizer:

--- a/mmgen/core/runners/apex_amp_utils.py
+++ b/mmgen/core/runners/apex_amp_utils.py
@@ -5,6 +5,20 @@ except ImportError:
 
 
 def apex_amp_initialize(models, optimizers, init_args=None, mode='gan'):
+    """Initialize apex.amp for mixed-precision training.
+
+    Args:
+        models (nn.Module | list[Module]): Modules to be wrapped with apex.amp.
+        optimizer (:obj:`Optimizer`, optional): Optimizer to be saved.
+        init_args (dict | None, optional): Config for amp initialization.
+            Defaults to None.
+        mode (str, optional): The moded used to initialize the apex.map.
+            Different modes lead to different wrapping mode for models and
+            optimizers. Defaults to 'gan'.
+
+    Returns:
+        Module, :obj:`Optimizer`: Wrapped module and optimizer.
+    """
     init_args = init_args or dict()
 
     if mode == 'gan':

--- a/mmgen/core/runners/apex_amp_utils.py
+++ b/mmgen/core/runners/apex_amp_utils.py
@@ -1,9 +1,7 @@
 try:
     from apex import amp
 except ImportError:
-    raise ImportError(
-        'Please install apex from https://www.github.com/nvidia/apex'
-        ' to run this example.')
+    amp = None
 
 
 def apex_amp_initialize(models, optimizers, init_args=None, mode='gan'):

--- a/mmgen/core/runners/apex_amp_utils.py
+++ b/mmgen/core/runners/apex_amp_utils.py
@@ -1,0 +1,23 @@
+try:
+    from apex import amp
+except ImportError:
+    raise ImportError(
+        'Please install apex from https://www.github.com/nvidia/apex'
+        ' to run this example.')
+
+
+def apex_amp_initialize(models, optimizers, init_args=None, mode='gan'):
+    init_args = init_args or dict()
+
+    if mode == 'gan':
+        _optmizers = [optimizers['generator'], optimizers['discriminator']]
+
+        models, _optmizers = amp.initialize(models, _optmizers, **init_args)
+        optimizers['generator'] = _optmizers[0]
+        optimizers['discriminator'] = _optmizers[1]
+
+        return models, optimizers
+
+    else:
+        raise NotImplementedError(
+            f'Cannot initialize apex.amp with mode {mode}')

--- a/mmgen/core/runners/checkpoint.py
+++ b/mmgen/core/runners/checkpoint.py
@@ -17,13 +17,19 @@ def save_checkpoint(model,
                     meta=None):
     """Save checkpoint to file.
 
-    The checkpoint will have 3 fields: ``meta``, ``state_dict`` and
+    The checkpoint will have 3 or more fields: ``meta``, ``state_dict`` and
     ``optimizer``. By default ``meta`` will contain version and time info.
+
+    In mixed-precision training, ``loss_scaler`` or ``amp.state_dict`` will be
+    saved in checkpoint.
 
     Args:
         model (Module): Module whose params are to be saved.
         filename (str): Checkpoint filename.
         optimizer (:obj:`Optimizer`, optional): Optimizer to be saved.
+        loss_scaler (Object, optional): Loss scaler used for FP16 training.
+        save_apex_amp (bool, optional): Whether to save apex.amp
+            ``state_dict``.
         meta (dict, optional): Metadata to be saved in checkpoint.
     """
     if meta is None:
@@ -51,9 +57,11 @@ def save_checkpoint(model,
         for name, optim in optimizer.items():
             checkpoint['optimizer'][name] = optim.state_dict()
 
+    # save loss scaler for mixed-precision (FP16) training
     if loss_scaler is not None:
         checkpoint['loss_scaler'] = loss_scaler.state_dict()
 
+    # save state_dict from apex.amp
     if save_apex_amp:
         from apex import amp
         checkpoint['amp'] = amp.state_dict()

--- a/mmgen/core/runners/checkpoint.py
+++ b/mmgen/core/runners/checkpoint.py
@@ -1,0 +1,81 @@
+import os.path as osp
+import time
+from tempfile import TemporaryDirectory
+
+import mmcv
+import torch
+from mmcv.parallel import is_module_wrapper
+from mmcv.runner.checkpoint import get_state_dict, weights_to_cpu
+from torch.optim import Optimizer
+
+
+def save_checkpoint(model,
+                    filename,
+                    optimizer=None,
+                    loss_scaler=None,
+                    meta=None):
+    """Save checkpoint to file.
+
+    The checkpoint will have 3 fields: ``meta``, ``state_dict`` and
+    ``optimizer``. By default ``meta`` will contain version and time info.
+
+    Args:
+        model (Module): Module whose params are to be saved.
+        filename (str): Checkpoint filename.
+        optimizer (:obj:`Optimizer`, optional): Optimizer to be saved.
+        meta (dict, optional): Metadata to be saved in checkpoint.
+    """
+    if meta is None:
+        meta = {}
+    elif not isinstance(meta, dict):
+        raise TypeError(f'meta must be a dict or None, but got {type(meta)}')
+    meta.update(mmcv_version=mmcv.__version__, time=time.asctime())
+
+    if is_module_wrapper(model):
+        model = model.module
+
+    if hasattr(model, 'CLASSES') and model.CLASSES is not None:
+        # save class name to the meta
+        meta.update(CLASSES=model.CLASSES)
+
+    checkpoint = {
+        'meta': meta,
+        'state_dict': weights_to_cpu(get_state_dict(model))
+    }
+    # save optimizer state dict in the checkpoint
+    if isinstance(optimizer, Optimizer):
+        checkpoint['optimizer'] = optimizer.state_dict()
+    elif isinstance(optimizer, dict):
+        checkpoint['optimizer'] = {}
+        for name, optim in optimizer.items():
+            checkpoint['optimizer'][name] = optim.state_dict()
+
+    if loss_scaler is not None:
+        checkpoint['loss_scaler'] = loss_scaler.state_dict()
+
+    if filename.startswith('pavi://'):
+        try:
+            from pavi import modelcloud
+            from pavi.exception import NodeNotFoundError
+        except ImportError:
+            raise ImportError(
+                'Please install pavi to load checkpoint from modelcloud.')
+        model_path = filename[7:]
+        root = modelcloud.Folder()
+        model_dir, model_name = osp.split(model_path)
+        try:
+            model = modelcloud.get(model_dir)
+        except NodeNotFoundError:
+            model = root.create_training_model(model_dir)
+        with TemporaryDirectory() as tmp_dir:
+            checkpoint_file = osp.join(tmp_dir, model_name)
+            with open(checkpoint_file, 'wb') as f:
+                torch.save(checkpoint, f)
+                f.flush()
+            model.create_file(checkpoint_file, name=model_name)
+    else:
+        mmcv.mkdir_or_exist(osp.dirname(filename))
+        # immediately flush buffer
+        with open(filename, 'wb') as f:
+            torch.save(checkpoint, f)
+            f.flush()

--- a/mmgen/core/runners/checkpoint.py
+++ b/mmgen/core/runners/checkpoint.py
@@ -13,6 +13,7 @@ def save_checkpoint(model,
                     filename,
                     optimizer=None,
                     loss_scaler=None,
+                    save_apex_amp=False,
                     meta=None):
     """Save checkpoint to file.
 
@@ -52,6 +53,10 @@ def save_checkpoint(model,
 
     if loss_scaler is not None:
         checkpoint['loss_scaler'] = loss_scaler.state_dict()
+
+    if save_apex_amp:
+        from apex import amp
+        checkpoint['amp'] = amp.state_dict()
 
     if filename.startswith('pavi://'):
         try:

--- a/mmgen/core/runners/dynamic_iterbased_runner.py
+++ b/mmgen/core/runners/dynamic_iterbased_runner.py
@@ -126,6 +126,10 @@ class DynamicIterBasedRunner(IterBasedRunner):
             Defaults to False.
         pass_training_status (bool, optional): Whether to pass the training
             status. Defaults to False.
+        fp16_loss_scalar (dict | None, optional): Config for fp16 GradScaler
+            from ``torch.cuda.amp``. Defaults to None.
+        use_apex_amp (bool, optional): Whether to use apex.amp to start mixed
+            precision training. Defaults to False.
     """
 
     def __init__(self,
@@ -294,6 +298,8 @@ class DynamicIterBasedRunner(IterBasedRunner):
             checkpoint (str): Checkpoint to resume from.
             resume_optimizer (bool, optional): Whether resume the optimizer(s)
                 if the checkpoint file includes optimizer(s). Default to True.
+            resume_loss_scaler (bool, optional): Whether to resume the loss
+                scaler (GradScaler) from ``torch.cuda.amp``. Defaults to True.
             map_location (str, optional): Same as :func:`torch.load`.
                 Default to 'default'.
         """

--- a/mmgen/core/runners/dynamic_iterbased_runner.py
+++ b/mmgen/core/runners/dynamic_iterbased_runner.py
@@ -156,6 +156,8 @@ class DynamicIterBasedRunner(IterBasedRunner):
         self.with_fp16_grad_scaler = False
         if fp16_loss_scaler is not None:
             self.loss_scaler = GradScaler(**fp16_loss_scaler)
+            self.with_fp16_grad_scaler = True
+            mmcv.print_log('Use FP16 grad scaler in Training', 'mmgen')
 
     def call_hook(self, fn_name):
         """Call all hooks.

--- a/mmgen/core/runners/dynamic_iterbased_runner.py
+++ b/mmgen/core/runners/dynamic_iterbased_runner.py
@@ -1,12 +1,26 @@
+import os.path as osp
+import platform
+import shutil
 import time
 import warnings
 from functools import partial
 
 import mmcv
+import torch
 import torch.distributed as dist
 from mmcv.parallel import collate, is_module_wrapper
 from mmcv.runner import HOOKS, RUNNERS, IterBasedRunner, get_host_info
+from torch.optim import Optimizer
 from torch.utils.data import DataLoader
+
+from .checkpoint import save_checkpoint
+
+try:
+    # If PyTorch version >= 1.6.0, torch.cuda.amp.GradScaler would be imported
+    # and used; otherwise, auto fp16 will adopt mmcv's implementation.
+    from torch.cuda.amp import GradScaler
+except ImportError:
+    pass
 
 
 class IterLoader:
@@ -118,6 +132,7 @@ class DynamicIterBasedRunner(IterBasedRunner):
                  *args,
                  is_dynamic_ddp=False,
                  pass_training_status=False,
+                 fp16_loss_scaler=None,
                  **kwargs):
         super().__init__(*args, **kwargs)
         if is_module_wrapper(self.model):
@@ -137,6 +152,10 @@ class DynamicIterBasedRunner(IterBasedRunner):
                 'Runner and model cannot contain optimizer at the same time.')
             self.optimizer_from_model = True
             self.optimizer = _model.optimizer
+
+        self.with_fp16_grad_scaler = False
+        if fp16_loss_scaler is not None:
+            self.loss_scaler = GradScaler(**fp16_loss_scaler)
 
     def call_hook(self, fn_name):
         """Call all hooks.
@@ -175,7 +194,14 @@ class DynamicIterBasedRunner(IterBasedRunner):
         if self.is_dynamic_ddp:
             kwargs.update(dict(ddp_reducer=self.model.reducer))
 
+        if self.with_fp16_grad_scaler:
+            kwargs.update(dict(loss_scaler=self.loss_scaler))
+
         outputs = self.model.train_step(data_batch, self.optimizer, **kwargs)
+
+        # the loss scaler should be updated after ``train_step``
+        if self.with_fp16_grad_scaler:
+            self.loss_scaler.update()
 
         # further check for the cases where the optimizer is built in
         # `train_step`.
@@ -246,6 +272,91 @@ class DynamicIterBasedRunner(IterBasedRunner):
         time.sleep(1)  # wait for some hooks like loggers to finish
         self.call_hook('after_epoch')
         self.call_hook('after_run')
+
+    def resume(self,
+               checkpoint,
+               resume_optimizer=True,
+               resume_loss_scaler=True,
+               map_location='default'):
+        """Resume model from checkpoint.
+
+        Args:
+            checkpoint (str): Checkpoint to resume from.
+            resume_optimizer (bool, optional): Whether resume the optimizer(s)
+                if the checkpoint file includes optimizer(s). Default to True.
+            map_location (str, optional): Same as :func:`torch.load`.
+                Default to 'default'.
+        """
+        if map_location == 'default':
+            device_id = torch.cuda.current_device()
+            checkpoint = self.load_checkpoint(
+                checkpoint,
+                map_location=lambda storage, loc: storage.cuda(device_id))
+        else:
+            checkpoint = self.load_checkpoint(
+                checkpoint, map_location=map_location)
+
+        self._epoch = checkpoint['meta']['epoch']
+        self._iter = checkpoint['meta']['iter']
+        self._inner_iter = checkpoint['meta']['iter']
+        if 'optimizer' in checkpoint and resume_optimizer:
+            if isinstance(self.optimizer, Optimizer):
+                self.optimizer.load_state_dict(checkpoint['optimizer'])
+            elif isinstance(self.optimizer, dict):
+                for k in self.optimizer.keys():
+                    self.optimizer[k].load_state_dict(
+                        checkpoint['optimizer'][k])
+            else:
+                raise TypeError(
+                    'Optimizer should be dict or torch.optim.Optimizer '
+                    f'but got {type(self.optimizer)}')
+
+        if 'loss_scaler' in checkpoint and resume_loss_scaler:
+            self.loss_scaler.load_state_dict(checkpoint['loss_scaler'])
+
+        self.logger.info(f'resumed from epoch: {self.epoch}, iter {self.iter}')
+
+    def save_checkpoint(self,
+                        out_dir,
+                        filename_tmpl='iter_{}.pth',
+                        meta=None,
+                        save_optimizer=True,
+                        create_symlink=True):
+        """Save checkpoint to file.
+
+        Args:
+            out_dir (str): Directory to save checkpoint files.
+            filename_tmpl (str, optional): Checkpoint file template.
+                Defaults to 'iter_{}.pth'.
+            meta (dict, optional): Metadata to be saved in checkpoint.
+                Defaults to None.
+            save_optimizer (bool, optional): Whether save optimizer.
+                Defaults to True.
+            create_symlink (bool, optional): Whether create symlink to the
+                latest checkpoint file. Defaults to True.
+        """
+        if meta is None:
+            meta = dict(iter=self.iter + 1, epoch=self.epoch + 1)
+        elif isinstance(meta, dict):
+            meta.update(iter=self.iter + 1, epoch=self.epoch + 1)
+        else:
+            raise TypeError(
+                f'meta should be a dict or None, but got {type(meta)}')
+        if self.meta is not None:
+            meta.update(self.meta)
+
+        filename = filename_tmpl.format(self.iter + 1)
+        filepath = osp.join(out_dir, filename)
+        optimizer = self.optimizer if save_optimizer else None
+        save_checkpoint(self.model, filepath, optimizer=optimizer, meta=meta)
+        # in some environments, `os.symlink` is not supported, you may need to
+        # set `create_symlink` to False
+        if create_symlink:
+            dst_file = osp.join(out_dir, 'latest.pth')
+            if platform.system() != 'Windows':
+                mmcv.symlink(filename, dst_file)
+            else:
+                shutil.copy(filepath, dst_file)
 
     def register_lr_hook(self, lr_config):
         if lr_config is None:

--- a/mmgen/core/runners/fp16_utils.py
+++ b/mmgen/core/runners/fp16_utils.py
@@ -1,0 +1,45 @@
+import torch
+
+
+def nan_to_num(x, nan=0.0, posinf=None, neginf=None, *, out=None):
+    r"""Replaces :literal:`NaN`, positive infinity, and negative infinity
+    values in :attr:`input` with the values specified by :attr:`nan`,
+    :attr:`posinf`, and :attr:`neginf`, respectively. By default,
+    :literal:`NaN`s are replaced with zero, positive infinity is replaced with
+    the greatest finite value representable by :attr:`input`'s dtype, and
+    negative infinity is replaced with the least finite value representable by
+    :attr:`input`'s dtype.
+
+    .. note::
+
+        This function is provided in ``PyTorch>=1.8.0``. Here is a
+        reimplementation to avoid attribute error in lower PyTorch version.
+
+    Args:
+        x (Tensor): Input tensor.
+        nan (Number, optional): the value to replace :literal:`NaN`\s with.
+            Default is zero.
+        posinf (Number, optional): if a Number, the value to replace positive
+            infinity values with. If None, positive infinity values are
+            replaced with the greatest finite value representable by
+            :attr:`input`'s dtype. Default is None.
+        neginf (Number, optional): if a Number, the value to replace negative
+            infinity values with. If None, negative infinity values are
+            replaced with the lowest finite value representable by
+            :attr:`input`'s dtype. Default is None.
+
+    Returns:
+        Tensor: Output tensor.
+    """
+    try:
+        return torch.nan_to_num(
+            x, nan=nan, posinf=posinf, neginf=neginf, out=out)
+    except AttributeError:
+        assert isinstance(x, torch.Tensor)
+        if posinf is None:
+            posinf = torch.finfo(x.dtype).max
+        if neginf is None:
+            neginf = torch.finfo(x.dtype).min
+        assert nan == 0
+        return torch.clamp(
+            x.unsqueeze(0).nansum(0), min=neginf, max=posinf, out=out)

--- a/mmgen/core/runners/fp16_utils.py
+++ b/mmgen/core/runners/fp16_utils.py
@@ -1,4 +1,17 @@
+import functools
+from collections import abc
+from inspect import getfullargspec
+
+import numpy as np
 import torch
+from mmcv.utils import TORCH_VERSION
+
+try:
+    # If PyTorch version >= 1.6.0, torch.cuda.amp.autocast would be imported
+    # and used; otherwise, auto fp16 will adopt mmcv's implementation.
+    from torch.cuda.amp import autocast
+except ImportError:
+    pass
 
 
 def nan_to_num(x, nan=0.0, posinf=None, neginf=None, *, out=None):
@@ -46,3 +59,126 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None, *, out=None):
         # x.unsqueeze(0).nansum(0)
         x[torch.isnan(x)] = 0.
         return torch.clamp(x, min=neginf, max=posinf, out=out)
+
+
+def cast_tensor_type(inputs, src_type, dst_type):
+    """Recursively convert Tensor in inputs from src_type to dst_type.
+
+    Args:
+        inputs: Inputs that to be casted.
+        src_type (torch.dtype): Source type..
+        dst_type (torch.dtype): Destination type.
+
+    Returns:
+        The same type with inputs, but all contained Tensors have been cast.
+    """
+    if isinstance(inputs, torch.Tensor):
+        return inputs.to(dst_type)
+    elif isinstance(inputs, str):
+        return inputs
+    elif isinstance(inputs, np.ndarray):
+        return inputs
+    elif isinstance(inputs, abc.Mapping):
+        return type(inputs)({
+            k: cast_tensor_type(v, src_type, dst_type)
+            for k, v in inputs.items()
+        })
+    elif isinstance(inputs, abc.Iterable):
+        return type(inputs)(
+            cast_tensor_type(item, src_type, dst_type) for item in inputs)
+    else:
+        return inputs
+
+
+def auto_fp16(apply_to=None, out_fp32=False):
+    """Decorator to enable fp16 training automatically.
+
+    This decorator is useful when you write custom modules and want to support
+    mixed precision training. If inputs arguments are fp32 tensors, they will
+    be converted to fp16 automatically. Arguments other than fp32 tensors are
+    ignored. If you are using PyTorch >= 1.6, torch.cuda.amp is used as the
+    backend, otherwise, original mmcv implementation will be adopted.
+
+    Args:
+        apply_to (Iterable, optional): The argument names to be converted.
+            `None` indicates all arguments.
+        out_fp32 (bool): Whether to convert the output back to fp32.
+
+    Example:
+
+        >>> import torch.nn as nn
+        >>> class MyModule1(nn.Module):
+        >>>
+        >>>     # Convert x and y to fp16
+        >>>     @auto_fp16()
+        >>>     def forward(self, x, y):
+        >>>         pass
+
+        >>> import torch.nn as nn
+        >>> class MyModule2(nn.Module):
+        >>>
+        >>>     # convert pred to fp16
+        >>>     @auto_fp16(apply_to=('pred', ))
+        >>>     def do_something(self, pred, others):
+        >>>         pass
+    """
+
+    def auto_fp16_wrapper(old_func):
+
+        @functools.wraps(old_func)
+        def new_func(*args, **kwargs):
+            # check if the module has set the attribute `fp16_enabled`, if not,
+            # just fallback to the original method.
+            if not isinstance(args[0], torch.nn.Module):
+                raise TypeError('@auto_fp16 can only be used to decorate the '
+                                'method of nn.Module')
+            if not (hasattr(args[0], 'fp16_enabled') and args[0].fp16_enabled):
+                return old_func(*args, **kwargs)
+
+            # define output type by class itself
+            if hasattr(args[0], 'out_fp32') and args[0].out_fp32:
+                _out_fp32 = True
+            else:
+                _out_fp32 = False
+
+            # get the arg spec of the decorated method
+            args_info = getfullargspec(old_func)
+            # get the argument names to be casted
+            # Here, we change the default behaviour with Yu Xiong's
+            # implementation
+            args_to_cast = [] if apply_to is None else apply_to
+            # convert the args that need to be processed
+            new_args = []
+            # NOTE: default args are not taken into consideration
+            if args:
+                arg_names = args_info.args[:len(args)]
+                for i, arg_name in enumerate(arg_names):
+                    if arg_name in args_to_cast:
+                        new_args.append(
+                            cast_tensor_type(args[i], torch.float, torch.half))
+                    else:
+                        new_args.append(args[i])
+            # convert the kwargs that need to be processed
+            new_kwargs = {}
+            if kwargs:
+                for arg_name, arg_value in kwargs.items():
+                    if arg_name in args_to_cast:
+                        new_kwargs[arg_name] = cast_tensor_type(
+                            arg_value, torch.float, torch.half)
+                    else:
+                        new_kwargs[arg_name] = arg_value
+            # apply converted arguments to the decorated method
+            if TORCH_VERSION != 'parrots' and TORCH_VERSION >= '1.6.0':
+                output = autocast(enabled=True)(old_func)(*new_args,
+                                                          **new_kwargs)
+            else:
+                # output = old_func(*new_args, **new_kwargs)
+                raise RuntimeError('Please use PyTorch >= 1.6.0')
+            # cast the results back to fp32 if necessary
+            if out_fp32 or _out_fp32:
+                output = cast_tensor_type(output, torch.half, torch.float)
+            return output
+
+        return new_func
+
+    return auto_fp16_wrapper

--- a/mmgen/core/runners/fp16_utils.py
+++ b/mmgen/core/runners/fp16_utils.py
@@ -41,5 +41,8 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None, *, out=None):
         if neginf is None:
             neginf = torch.finfo(x.dtype).min
         assert nan == 0
-        return torch.clamp(
-            x.unsqueeze(0).nansum(0), min=neginf, max=posinf, out=out)
+        # a better choice is to use nansum, but this function is not supported
+        # in PyTorch 1.5
+        # x.unsqueeze(0).nansum(0)
+        x[torch.isnan(x)] = 0.
+        return torch.clamp(x, min=neginf, max=posinf, out=out)

--- a/mmgen/core/runners/fp16_utils.py
+++ b/mmgen/core/runners/fp16_utils.py
@@ -49,7 +49,9 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None, *, out=None):
         return torch.nan_to_num(
             x, nan=nan, posinf=posinf, neginf=neginf, out=out)
     except AttributeError:
-        assert isinstance(x, torch.Tensor)
+        if not isinstance(x, torch.Tensor):
+            raise TypeError(
+                f'argument input (position 1) must be Tensor, not {type(x)}')
         if posinf is None:
             posinf = torch.finfo(x.dtype).max
         if neginf is None:

--- a/mmgen/core/runners/fp16_utils.py
+++ b/mmgen/core/runners/fp16_utils.py
@@ -4,6 +4,7 @@ from inspect import getfullargspec
 
 import numpy as np
 import torch
+import torch.nn as nn
 from mmcv.utils import TORCH_VERSION
 
 try:
@@ -74,6 +75,8 @@ def cast_tensor_type(inputs, src_type, dst_type):
     """
     if isinstance(inputs, torch.Tensor):
         return inputs.to(dst_type)
+    if isinstance(inputs, nn.Module):
+        return inputs
     elif isinstance(inputs, str):
         return inputs
     elif isinstance(inputs, np.ndarray):

--- a/mmgen/datasets/__init__.py
+++ b/mmgen/datasets/__init__.py
@@ -4,6 +4,7 @@ from .grow_scale_image_dataset import GrowScaleImgDataset
 from .paired_image_dataset import PairedImageDataset
 from .pipelines import (Collect, Compose, Flip, ImageToTensor,
                         LoadImageFromFile, Normalize, Resize, ToTensor)
+from .quick_test_dataset import QuickTestImageDataset
 from .samplers import DistributedSampler
 from .singan_dataset import SinGANDataset
 from .unconditional_image_dataset import UnconditionalImageDataset
@@ -14,5 +15,5 @@ __all__ = [
     'DistributedSampler', 'UnconditionalImageDataset', 'Compose', 'ToTensor',
     'ImageToTensor', 'Collect', 'Flip', 'Resize', 'RepeatDataset', 'Normalize',
     'GrowScaleImgDataset', 'SinGANDataset', 'PairedImageDataset',
-    'UnpairedImageDataset'
+    'UnpairedImageDataset', 'QuickTestImageDataset'
 ]

--- a/mmgen/datasets/quick_test_dataset.py
+++ b/mmgen/datasets/quick_test_dataset.py
@@ -6,20 +6,11 @@ from .builder import DATASETS
 
 @DATASETS.register_module()
 class QuickTestImageDataset(Dataset):
-    """Uncoditional Image Dataset.
-
-    This dataset contains raw images for training unconditional GANs. Given
-    a root dir, we will recursively find all images in this root. The
-    transformation on data is defined by the pipeline.
+    """Dataset for quickly testing the correctness.
 
     Args:
-        imgs_root (str): Root path for unconditional images.
-        pipeline (list[dict | callable]): A sequence of data transforms.
-        test_mode (bool, optional): If True, the dataset will work in test
-            mode. Otherwise, in train mode. Default to False.
+        size (tuple[int]): The size of the images. Defaults to `None`.
     """
-
-    _VALID_IMG_SUFFIX = ('.jpg', '.png', '.jpeg', '.JPEG')
 
     def __init__(self, *args, size=None, **kwargs):
         super().__init__()

--- a/mmgen/datasets/quick_test_dataset.py
+++ b/mmgen/datasets/quick_test_dataset.py
@@ -1,0 +1,32 @@
+import torch
+from torch.utils.data import Dataset
+
+from .builder import DATASETS
+
+
+@DATASETS.register_module()
+class QuickTestImageDataset(Dataset):
+    """Uncoditional Image Dataset.
+
+    This dataset contains raw images for training unconditional GANs. Given
+    a root dir, we will recursively find all images in this root. The
+    transformation on data is defined by the pipeline.
+
+    Args:
+        imgs_root (str): Root path for unconditional images.
+        pipeline (list[dict | callable]): A sequence of data transforms.
+        test_mode (bool, optional): If True, the dataset will work in test
+            mode. Otherwise, in train mode. Default to False.
+    """
+
+    _VALID_IMG_SUFFIX = ('.jpg', '.png', '.jpeg', '.JPEG')
+
+    def __init__(self, *args, size=None, **kwargs):
+        super().__init__()
+        self.size = size
+
+    def __len__(self):
+        return 10000
+
+    def __getitem__(self, idx):
+        return dict(real_img=torch.randn(3, self.size[0], self.size[1]))

--- a/mmgen/datasets/quick_test_dataset.py
+++ b/mmgen/datasets/quick_test_dataset.py
@@ -15,9 +15,10 @@ class QuickTestImageDataset(Dataset):
     def __init__(self, *args, size=None, **kwargs):
         super().__init__()
         self.size = size
+        self.img_tensor = torch.randn(3, self.size[0], self.size[1])
 
     def __len__(self):
         return 10000
 
     def __getitem__(self, idx):
-        return dict(real_img=torch.randn(3, self.size[0], self.size[1]))
+        return dict(real_img=self.img_tensor)

--- a/mmgen/models/architectures/stylegan/generator_discriminator_v2.py
+++ b/mmgen/models/architectures/stylegan/generator_discriminator_v2.py
@@ -502,7 +502,10 @@ class StyleGAN2Discriminator(nn.Module):
 
         in_channels = channels[in_size]
 
-        convs = [ConvDownLayer(3, channels[in_size], 1)]
+        _use_fp16 = num_fp16_scales > 0
+        convs = [
+            ConvDownLayer(3, channels[in_size], 1, fp16_enabled=_use_fp16)
+        ]
 
         for i in range(log_size, 2, -1):
             out_channel = channels[2**(i - 1)]

--- a/mmgen/models/architectures/stylegan/generator_discriminator_v2.py
+++ b/mmgen/models/architectures/stylegan/generator_discriminator_v2.py
@@ -481,8 +481,10 @@ class StyleGAN2Discriminator(nn.Module):
                  channel_multiplier=2,
                  blur_kernel=[1, 3, 3, 1],
                  mbstd_cfg=dict(group_size=4, channel_groups=1),
+                 num_fp16_scales=0,
                  pretrained=None):
         super().__init__()
+        self.num_fp16_scale = num_fp16_scales
 
         channels = {
             4: 512,
@@ -505,7 +507,15 @@ class StyleGAN2Discriminator(nn.Module):
         for i in range(log_size, 2, -1):
             out_channel = channels[2**(i - 1)]
 
-            convs.append(ResBlock(in_channels, out_channel, blur_kernel))
+            # add fp16 training for higher resolutions
+            _use_fp16 = (log_size - i) < num_fp16_scales
+
+            convs.append(
+                ResBlock(
+                    in_channels,
+                    out_channel,
+                    blur_kernel,
+                    fp16_enabled=_use_fp16))
 
             in_channels = out_channel
 

--- a/mmgen/models/architectures/stylegan/generator_discriminator_v2.py
+++ b/mmgen/models/architectures/stylegan/generator_discriminator_v2.py
@@ -72,9 +72,13 @@ class StyleGANv2Generator(nn.Module):
         mix_prob (float, optional): Mixing probability. The value should be
             in range of [0, 1]. Defaults to ``0.9``.
         num_fp16_scales (int, optional): The number of resolutions to use auto
-            fp16 training. Defaults to 0.
+            fp16 training. Different from ``fp16_enabled``, this argument
+            allows users to adopt FP16 training only in several blocks.
+            This behaviour is much more similar to the offical implementation
+            by Tero. Defaults to 0.
         fp16_enabled (bool, optional): Whether to use fp16 training in this
-            module. Defaults to False.
+            module. If this flag is `True`, the whole module will be wrapped
+            with ``auto_fp16``. Defaults to False.
         pretrained (dict | None, optional): Information for pretained models.
             The necessary key is 'ckpt_path'. Besides, you can also provide
             'prefix' to load the generator part from the whole state dict.
@@ -159,6 +163,9 @@ class StyleGANv2Generator(nn.Module):
         for i in range(3, self.log_size + 1):
             out_channels_ = self.channels[2**i]
 
+            # If `fp16_enabled` is True, all of layers will be run in auto
+            # FP16. In the case of `num_fp16_sacles` > 0, only partial
+            # layers will be run in fp16.
             _use_fp16 = (self.log_size - i) < num_fp16_scales or fp16_enabled
 
             self.convs.append(

--- a/mmgen/models/architectures/stylegan/modules/styleganv2_modules.py
+++ b/mmgen/models/architectures/stylegan/modules/styleganv2_modules.py
@@ -935,9 +935,9 @@ class ConvDownLayer(nn.Sequential):
         if self.fp16_enabled:
             self.half()
 
-    @auto_fp16()
-    def forward(self, *args, **kwargs):
-        return super().forward(*args, **kwargs)
+    @auto_fp16(apply_to=('x', ))
+    def forward(self, x):
+        return super().forward(x)
 
 
 class ResBlock(nn.Module):

--- a/mmgen/models/architectures/stylegan/modules/styleganv2_modules.py
+++ b/mmgen/models/architectures/stylegan/modules/styleganv2_modules.py
@@ -21,8 +21,17 @@ from mmgen.models.common import AllGatherLayer
 
 
 class _FusedBiasLeakyReLU(FusedBiasLeakyReLU):
+    """Wrap FusedBiasLeakyReLU to support FP16 training."""
 
     def forward(self, x):
+        """Forward function.
+
+        Args:
+            x (Tensor): Input feature map with shape of (N, C, ...).
+
+        Returns:
+            Tensor: Output feature map.
+        """
         return fused_bias_leakyrelu(x, self.bias.to(x.dtype),
                                     self.negative_slope, self.scale)
 

--- a/mmgen/models/gans/base_gan.py
+++ b/mmgen/models/gans/base_gan.py
@@ -5,26 +5,13 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
-from mmgen.core.runners.fp16_utils import nan_to_num
-
 
 class BaseGAN(nn.Module, metaclass=ABCMeta):
+    """BaseGAN Module."""
 
     def __init__(self):
         super().__init__()
         self.fp16_enabled = False
-
-        # whether to clamp grad. This is commonly used in FP16 training.
-        self.clamp_inf_nan_grad = False
-
-    def _clamp_inf_nan_grad(self, model):
-        clamp_args = dict(posinf=1e5, neginf=1e-5)
-        if hasattr(self, 'nan2num_cfg'):
-            clamp_args.update(self.nan2num_cfg)
-
-        for param in model.parameters():
-            if param.grad is not None:
-                nan_to_num(param.grad, nan=0, out=param.grad, **clamp_args)
 
     @property
     def with_disc(self):

--- a/mmgen/models/gans/base_gan.py
+++ b/mmgen/models/gans/base_gan.py
@@ -5,12 +5,26 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 
+from mmgen.core.runners.fp16_utils import nan_to_num
+
 
 class BaseGAN(nn.Module, metaclass=ABCMeta):
 
     def __init__(self):
         super().__init__()
         self.fp16_enabled = False
+
+        # whether to clamp grad. This is commonly used in FP16 training.
+        self.clamp_inf_nan_grad = False
+
+    def _clamp_inf_nan_grad(self, model):
+        clamp_args = dict(posinf=1e5, neginf=1e-5)
+        if hasattr(self, 'nan2num_cfg'):
+            clamp_args.update(self.nan2num_cfg)
+
+        for param in model.parameters():
+            if param.grad is not None:
+                nan_to_num(param.grad, nan=0, out=param.grad, **clamp_args)
 
     @property
     def with_disc(self):

--- a/mmgen/models/gans/static_unconditional_gan.py
+++ b/mmgen/models/gans/static_unconditional_gan.py
@@ -120,6 +120,7 @@ class StaticUnconditionalGAN(BaseGAN):
                    optimizer,
                    ddp_reducer=None,
                    loss_scaler=None,
+                   use_apex_amp=False,
                    running_status=None):
         """Train step function.
 
@@ -193,6 +194,12 @@ class StaticUnconditionalGAN(BaseGAN):
         if loss_scaler:
             # add support for fp16
             loss_scaler.scale(loss_disc).backward()
+        elif use_apex_amp:
+            from apex import amp
+            with amp.scale_loss(
+                    loss_disc, optimizer['discriminator'],
+                    loss_id=0) as scaled_loss_disc:
+                scaled_loss_disc.backward()
         else:
             loss_disc.backward()
 
@@ -247,6 +254,12 @@ class StaticUnconditionalGAN(BaseGAN):
 
         if loss_scaler:
             loss_scaler.scale(loss_gen).backward()
+        elif use_apex_amp:
+            from apex import amp
+            with amp.scale_loss(
+                    loss_gen, optimizer['generator'],
+                    loss_id=1) as scaled_loss_disc:
+                scaled_loss_disc.backward()
         else:
             loss_gen.backward()
 

--- a/mmgen/models/gans/static_unconditional_gan.py
+++ b/mmgen/models/gans/static_unconditional_gan.py
@@ -97,12 +97,6 @@ class StaticUnconditionalGAN(BaseGAN):
             # use deepcopy to guarantee the consistency
             self.generator_ema = deepcopy(self.generator)
 
-        # fp16 settings
-        self.clamp_inf_nan_grad = self.train_cfg.get('clamp_inf_nan_grad',
-                                                     False)
-        if self.clamp_inf_nan_grad:
-            self.nan2num_cfg = self.train_cfg.get('nan2num_cfg', dict())
-
     def _parse_test_cfg(self):
         """Parsing test config and set some attributes for testing."""
         if self.test_cfg is None:
@@ -203,9 +197,6 @@ class StaticUnconditionalGAN(BaseGAN):
         else:
             loss_disc.backward()
 
-        if self.clamp_inf_nan_grad:
-            self._clamp_inf_nan_grad(self.discriminator)
-
         if loss_scaler:
             loss_scaler.unscale_(optimizer['discriminator'])
             # note that we do not contain clip_grad procedure
@@ -262,9 +253,6 @@ class StaticUnconditionalGAN(BaseGAN):
                 scaled_loss_disc.backward()
         else:
             loss_gen.backward()
-
-        if self.clamp_inf_nan_grad:
-            self._clamp_inf_nan_grad(self.generator)
 
         if loss_scaler:
             loss_scaler.unscale_(optimizer['generator'])

--- a/mmgen/models/gans/static_unconditional_gan.py
+++ b/mmgen/models/gans/static_unconditional_gan.py
@@ -99,6 +99,8 @@ class StaticUnconditionalGAN(BaseGAN):
 
         # fp16 settings
         self.clamp_inf_nan_grad = self.train_cfg('clamp_inf_nan_grad', False)
+        if self.clamp_inf_nan_grad:
+            self.nan2num_cfg = self.train_cfg.get('nan2num_cfg', dict())
 
     def _parse_test_cfg(self):
         """Parsing test config and set some attributes for testing."""

--- a/mmgen/models/gans/static_unconditional_gan.py
+++ b/mmgen/models/gans/static_unconditional_gan.py
@@ -98,7 +98,8 @@ class StaticUnconditionalGAN(BaseGAN):
             self.generator_ema = deepcopy(self.generator)
 
         # fp16 settings
-        self.clamp_inf_nan_grad = self.train_cfg('clamp_inf_nan_grad', False)
+        self.clamp_inf_nan_grad = self.train_cfg.get('clamp_inf_nan_grad',
+                                                     False)
         if self.clamp_inf_nan_grad:
             self.nan2num_cfg = self.train_cfg.get('nan2num_cfg', dict())
 

--- a/mmgen/models/losses/gen_auxiliary_loss.py
+++ b/mmgen/models/losses/gen_auxiliary_loss.py
@@ -77,7 +77,10 @@ def gen_path_regularizer(generator,
         grad = grad * inv_scale
     elif use_apex_amp:
         from apex.amp._amp_state import _amp_state
-        _loss_scaler = _amp_state.loss_scalers[0]
+
+        # by default, we use loss_scalers[0] for discriminator and
+        # loss_scalers[1] for generator
+        _loss_scaler = _amp_state.loss_scalers[1]
         loss = _loss_scaler.loss_scale() * ((fake_img * noise).sum()).float()
 
         grad = autograd.grad(

--- a/mmgen/models/losses/gen_auxiliary_loss.py
+++ b/mmgen/models/losses/gen_auxiliary_loss.py
@@ -62,10 +62,11 @@ def gen_path_regularizer(generator,
         fake_img.shape[2] * fake_img.shape[3])
 
     if loss_scaler:
+        loss = loss_scaler.scale((fake_img * noise).sum())[0]
         grad = autograd.grad(
-            outputs=loss_scaler.scale((fake_img * noise).sum()),
+            outputs=loss,
             inputs=latents,
-            grad_outputs=torch.ones(()).to(fake_img),
+            grad_outputs=torch.ones(()).to(loss),
             create_graph=True,
             retain_graph=True,
             only_inputs=True)[0]

--- a/mmgen/ops/conv2d_gradfix.py
+++ b/mmgen/ops/conv2d_gradfix.py
@@ -249,6 +249,8 @@ def _conv2d_gradfix(transpose, weight_shape, stride, padding, output_padding,
         @staticmethod
         def forward(ctx, input, weight, bias):
             assert weight.shape == weight_shape
+            # keep the consistent datatype for FP16 training
+            weight = weight.to(input.dtype)
             if not transpose:
                 output = torch.nn.functional.conv2d(
                     input=input, weight=weight, bias=bias, **common_kwargs)
@@ -307,6 +309,9 @@ def _conv2d_gradfix(transpose, weight_shape, stride, padding, output_padding,
                     torch.backends.cudnn.benchmark,
                     torch.backends.cudnn.deterministic
                 ]
+
+            # keep the consistent datatype for FP16 training
+            input = input.to(grad_output.dtype)
             grad_weight = op(weight_shape, grad_output, input, padding, stride,
                              dilation, groups, *flags)
             assert grad_weight.shape == weight_shape

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ split_before_expression_after_opening_paren=true
 [isort]
 line_length=79
 multi_line_output=0
-known_standard_library=argparse,contextlib,subprocess,unittest,tempfile,copy,pkg_resources,logging,pickle,platform,setuptools,abc,collections,functools,os,math,time,warnings,random,shutil,sys
+known_standard_library=argparse,inspect,contextlib,subprocess,unittest,tempfile,copy,pkg_resources,logging,pickle,platform,setuptools,abc,collections,functools,os,math,time,warnings,random,shutil,sys
 known_first_party=mmgen
 known_third_party=PIL,cv2,mmcv,numpy,prettytable,pytest,scipy,torch,torchvision,tqdm
 no_lines_before=STDLIB,LOCALFOLDER

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ split_before_expression_after_opening_paren=true
 [isort]
 line_length=79
 multi_line_output=0
-known_standard_library=argparse,contextlib,subprocess,unittest,tempfile,copy,pkg_resources,logging,pickle,setuptools,abc,collections,functools,os,math,time,warnings,random,shutil,sys
+known_standard_library=argparse,contextlib,subprocess,unittest,tempfile,copy,pkg_resources,logging,pickle,platform,setuptools,abc,collections,functools,os,math,time,warnings,random,shutil,sys
 known_first_party=mmgen
 known_third_party=PIL,cv2,mmcv,numpy,prettytable,pytest,scipy,torch,torchvision,tqdm
 no_lines_before=STDLIB,LOCALFOLDER

--- a/tests/test_cores/test_fp16_utils.py
+++ b/tests/test_cores/test_fp16_utils.py
@@ -19,9 +19,6 @@ def test_nan_to_num():
     with pytest.raises(TypeError):
         nan_to_num(1)
 
-    with pytest.raises(AssertionError):
-        res = nan_to_num(a, nan=2, posinf=255., neginf=-255.)
-
 
 def test_cast_tensor_type():
     inputs = torch.FloatTensor([5.])

--- a/tests/test_cores/test_fp16_utils.py
+++ b/tests/test_cores/test_fp16_utils.py
@@ -1,0 +1,203 @@
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+from mmcv.utils import TORCH_VERSION
+
+from mmgen.core.runners.fp16_utils import auto_fp16, cast_tensor_type
+
+
+def test_cast_tensor_type():
+    inputs = torch.FloatTensor([5.])
+    src_type = torch.float32
+    dst_type = torch.int32
+    outputs = cast_tensor_type(inputs, src_type, dst_type)
+    assert isinstance(outputs, torch.Tensor)
+    assert outputs.dtype == dst_type
+
+    inputs = 'tensor'
+    src_type = str
+    dst_type = str
+    outputs = cast_tensor_type(inputs, src_type, dst_type)
+    assert isinstance(outputs, str)
+
+    inputs = np.array([5.])
+    src_type = np.ndarray
+    dst_type = np.ndarray
+    outputs = cast_tensor_type(inputs, src_type, dst_type)
+    assert isinstance(outputs, np.ndarray)
+
+    inputs = dict(
+        tensor_a=torch.FloatTensor([1.]), tensor_b=torch.FloatTensor([2.]))
+    src_type = torch.float32
+    dst_type = torch.int32
+    outputs = cast_tensor_type(inputs, src_type, dst_type)
+    assert isinstance(outputs, dict)
+    assert outputs['tensor_a'].dtype == dst_type
+    assert outputs['tensor_b'].dtype == dst_type
+
+    inputs = [torch.FloatTensor([1.]), torch.FloatTensor([2.])]
+    src_type = torch.float32
+    dst_type = torch.int32
+    outputs = cast_tensor_type(inputs, src_type, dst_type)
+    assert isinstance(outputs, list)
+    assert outputs[0].dtype == dst_type
+    assert outputs[1].dtype == dst_type
+
+    inputs = 5
+    outputs = cast_tensor_type(inputs, None, None)
+    assert isinstance(outputs, int)
+
+    inputs = nn.Sequential(nn.Conv2d(2, 2, 3), nn.ReLU())
+    outputs = cast_tensor_type(inputs, None, None)
+    assert isinstance(outputs, nn.Module)
+
+
+@pytest.mark.skipif(
+    not TORCH_VERSION >= '1.6.0', reason='Lower PyTorch version')
+def test_auto_fp16_func():
+
+    with pytest.raises(TypeError):
+        # ExampleObject is not a subclass of nn.Module
+
+        class ExampleObject(object):
+
+            @auto_fp16()
+            def __call__(self, x):
+                return x
+
+        model = ExampleObject()
+        input_x = torch.ones(1, dtype=torch.float32)
+        model(input_x)
+
+    # apply to all input args
+    class ExampleModule(nn.Module):
+
+        @auto_fp16()
+        def forward(self, x, y):
+            return x, y
+
+    model = ExampleModule()
+    input_x = torch.ones(1, dtype=torch.float32)
+    input_y = torch.ones(1, dtype=torch.float32)
+    output_x, output_y = model(input_x, input_y)
+    assert output_x.dtype == torch.float32
+    assert output_y.dtype == torch.float32
+
+    model.fp16_enabled = True
+    output_x, output_y = model(input_x, input_y)
+    assert output_x.dtype == torch.float32
+    assert output_y.dtype == torch.float32
+
+    if torch.cuda.is_available():
+        model.cuda()
+        output_x, output_y = model(input_x.cuda(), input_y.cuda())
+        assert output_x.dtype == torch.float32
+        assert output_y.dtype == torch.float32
+
+    # apply to specified input args
+    class ExampleModule(nn.Module):
+
+        @auto_fp16(apply_to=('x', ))
+        def forward(self, x, y):
+            return x, y
+
+    model = ExampleModule()
+    input_x = torch.ones(1, dtype=torch.float32)
+    input_y = torch.ones(1, dtype=torch.float32)
+    output_x, output_y = model(input_x, input_y)
+    assert output_x.dtype == torch.float32
+    assert output_y.dtype == torch.float32
+
+    model.fp16_enabled = True
+    output_x, output_y = model(input_x, input_y)
+    assert output_x.dtype == torch.half
+    assert output_y.dtype == torch.float32
+
+    if torch.cuda.is_available():
+        model.cuda()
+        output_x, output_y = model(input_x.cuda(), input_y.cuda())
+        assert output_x.dtype == torch.half
+        assert output_y.dtype == torch.float32
+
+    # apply to optional input args
+    class ExampleModule(nn.Module):
+
+        @auto_fp16(apply_to=('x', 'y'))
+        def forward(self, x, y=None, z=None):
+            return x, y, z
+
+    model = ExampleModule()
+    input_x = torch.ones(1, dtype=torch.float32)
+    input_y = torch.ones(1, dtype=torch.float32)
+    input_z = torch.ones(1, dtype=torch.float32)
+    output_x, output_y, output_z = model(input_x, y=input_y, z=input_z)
+    assert output_x.dtype == torch.float32
+    assert output_y.dtype == torch.float32
+    assert output_z.dtype == torch.float32
+
+    model.fp16_enabled = True
+    output_x, output_y, output_z = model(input_x, y=input_y, z=input_z)
+    assert output_x.dtype == torch.half
+    assert output_y.dtype == torch.half
+    assert output_z.dtype == torch.float32
+
+    if torch.cuda.is_available():
+        model.cuda()
+        output_x, output_y, output_z = model(
+            input_x.cuda(), y=input_y.cuda(), z=input_z.cuda())
+        assert output_x.dtype == torch.half
+        assert output_y.dtype == torch.half
+        assert output_z.dtype == torch.float32
+
+    # out_fp32=True
+    class ExampleModule(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.out_fp32 = True
+
+        @auto_fp16(apply_to=('x', 'y'))
+        def forward(self, x, y=None, z=None):
+            return x, y, z
+
+    model = ExampleModule()
+    model.fp16_enabled = True
+
+    input_x = torch.ones(1, dtype=torch.half)
+    input_y = torch.ones(1, dtype=torch.float32)
+    input_z = torch.ones(1, dtype=torch.float32)
+    output_x, output_y, output_z = model(input_x, y=input_y, z=input_z)
+    assert output_x.dtype == torch.float32
+    assert output_y.dtype == torch.float32
+    assert output_z.dtype == torch.float32
+
+    # out_fp32=True
+    class ExampleModule(nn.Module):
+
+        @auto_fp16(apply_to=('x', 'y'), out_fp32=True)
+        def forward(self, x, y=None, z=None):
+            return x, y, z
+
+    model = ExampleModule()
+    input_x = torch.ones(1, dtype=torch.half)
+    input_y = torch.ones(1, dtype=torch.float32)
+    input_z = torch.ones(1, dtype=torch.float32)
+    output_x, output_y, output_z = model(input_x, y=input_y, z=input_z)
+    assert output_x.dtype == torch.half
+    assert output_y.dtype == torch.float32
+    assert output_z.dtype == torch.float32
+
+    model.fp16_enabled = True
+    output_x, output_y, output_z = model(input_x, y=input_y, z=input_z)
+    assert output_x.dtype == torch.float32
+    assert output_y.dtype == torch.float32
+    assert output_z.dtype == torch.float32
+
+    if torch.cuda.is_available():
+        model.cuda()
+        output_x, output_y, output_z = model(
+            input_x.cuda(), y=input_y.cuda(), z=input_z.cuda())
+        assert output_x.dtype == torch.float32
+        assert output_y.dtype == torch.float32
+        assert output_z.dtype == torch.float32

--- a/tests/test_cores/test_fp16_utils.py
+++ b/tests/test_cores/test_fp16_utils.py
@@ -16,7 +16,7 @@ def test_nan_to_num():
     res = nan_to_num(a)
     assert res.shape == (3, )
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         nan_to_num(1)
 
     with pytest.raises(AssertionError):

--- a/tests/test_cores/test_fp16_utils.py
+++ b/tests/test_cores/test_fp16_utils.py
@@ -4,7 +4,23 @@ import torch
 import torch.nn as nn
 from mmcv.utils import TORCH_VERSION
 
-from mmgen.core.runners.fp16_utils import auto_fp16, cast_tensor_type
+from mmgen.core.runners.fp16_utils import (auto_fp16, cast_tensor_type,
+                                           nan_to_num)
+
+
+def test_nan_to_num():
+    a = torch.tensor([float('inf'), float('nan'), 2.])
+    res = nan_to_num(a, posinf=255., neginf=-255.)
+    assert (res == torch.tensor([255., 0., 2.])).all()
+
+    res = nan_to_num(a)
+    assert res.shape == (3, )
+
+    with pytest.raises(AssertionError):
+        nan_to_num(1)
+
+    with pytest.raises(AssertionError):
+        res = nan_to_num(a, nan=2, posinf=255., neginf=-255.)
 
 
 def test_cast_tensor_type():

--- a/tests/test_datasets/test_quicktest_dataset.py
+++ b/tests/test_datasets/test_quicktest_dataset.py
@@ -10,4 +10,4 @@ class TestQuickTest:
     def test_quicktest_dataset(self):
         assert len(self.dataset) == 10000
         img = self.dataset[2]
-        assert img.shape == (3, 256, 256)
+        assert img['real_img'].shape == (3, 256, 256)

--- a/tests/test_datasets/test_quicktest_dataset.py
+++ b/tests/test_datasets/test_quicktest_dataset.py
@@ -1,0 +1,13 @@
+from mmgen.datasets.quick_test_dataset import QuickTestImageDataset
+
+
+class TestQuickTest:
+
+    @classmethod
+    def setup_class(cls):
+        cls.dataset = QuickTestImageDataset(size=(256, 256))
+
+    def test_quicktest_dataset(self):
+        assert len(self.dataset) == 10000
+        img = self.dataset[2]
+        assert img.shape == (3, 256, 256)

--- a/tests/test_modules/test_stylev2_archs.py
+++ b/tests/test_modules/test_stylev2_archs.py
@@ -178,6 +178,12 @@ class TestStyleGAN2Generator:
         assert res.shape == (2, 3, 256, 256)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
+    def test_fp16_cuda(self):
+        g = StyleGANv2Generator(**self.default_cfg, num_fp16_scales=2).cuda()
+        res = g(None, num_batches=2)
+        assert res.dtype == torch.float16
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_g_cuda(self):
         # test default config
         g = StyleGANv2Generator(**self.default_cfg).cuda()
@@ -405,6 +411,15 @@ class TestStyleGANv2Disc:
         img = torch.randn((2, 3, 64, 64)).cuda()
         score = d(img)
         assert score.shape == (2, 1)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
+    def test_fp16_stylegan2_disc_cuda(self):
+        d = StyleGAN2Discriminator(
+            **self.default_cfg, num_fp16_scales=2).cuda()
+        img = torch.randn((2, 3, 64, 64)).cuda()
+        score = d(img)
+        assert score.shape == (2, 1)
+        assert score.dtype == torch.float32
 
 
 class TestMSStyleGANv2Disc:

--- a/tests/test_modules/test_stylev2_archs.py
+++ b/tests/test_modules/test_stylev2_archs.py
@@ -179,9 +179,10 @@ class TestStyleGAN2Generator:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_fp16_cuda(self):
+
         g = StyleGANv2Generator(**self.default_cfg, num_fp16_scales=2).cuda()
         res = g(None, num_batches=2)
-        assert res.dtype == torch.float16
+        assert res.dtype == torch.float32
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_g_cuda(self):

--- a/tests/test_modules/test_stylev2_archs.py
+++ b/tests/test_modules/test_stylev2_archs.py
@@ -178,9 +178,13 @@ class TestStyleGAN2Generator:
         assert res.shape == (2, 3, 256, 256)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
-    def test_fp16_cuda(self):
+    def test_fp16_stylegan2_G_cuda(self):
 
         g = StyleGANv2Generator(**self.default_cfg, num_fp16_scales=2).cuda()
+        res = g(None, num_batches=2)
+        assert res.dtype == torch.float32
+
+        g = StyleGANv2Generator(**self.default_cfg, fp16_enabled=True).cuda()
         res = g(None, num_batches=2)
         assert res.dtype == torch.float32
 

--- a/tools/dist_train.sh
+++ b/tools/dist_train.sh
@@ -4,5 +4,5 @@ CONFIG=$1
 GPUS=$2
 PORT=${PORT:-29500}
 
-
+PYTHONPATH="$(dirname $0)/..":$PYTHONPATH \
 python -m torch.distributed.launch --nproc_per_node=$GPUS --master_port=$PORT tools/train.py $CONFIG --launcher pytorch ${@:3}


### PR DESCRIPTION
## Motivation
Add support for mixed-precision training with `torch.cuda.amp` (PyTorch >= 1.6.0) and `apex.amp` (need to install [apex](https://github.com/NVIDIA/apex) mannually). Since `torch.cuda.amp` is only supported after `1.6.0`, we add the support for `apex.amp`, so that users can adopt mixed-precision training for previous PyTorch version.

## Modification
* add fp16_utils to introduce `auto_fp16` function
* add the example for training stylegan2
