### PR TITLE
[Fix] fix loss of sample-cfg argument 

### DIFF
--- a/tools/evaluation.py
+++ b/tools/evaluation.py
@@ -63,6 +63,11 @@ def parse_args():
         action=DictAction,
         help='override some settings in the used config, the key-value pair '
         'in xxx=yyy format will be merged into config file.')
+    parser.add_argument(
+        '--sample-cfg',
+        nargs='+', 
+        action=DictAction,
+        help='Other customized kwargs for sampling function')
     args = parser.parse_args()
     return args
 

--- a/tools/evaluation.py
+++ b/tools/evaluation.py
@@ -65,7 +65,7 @@ def parse_args():
         'in xxx=yyy format will be merged into config file.')
     parser.add_argument(
         '--sample-cfg',
-        nargs='+', 
+        nargs='+',
         action=DictAction,
         help='Other customized kwargs for sampling function')
     args = parser.parse_args()


### PR DESCRIPTION
I have tested on `PGGAN` with `--sample-cfg transition_weight=xxx` and it works.