### PR TITLE
Change 'Learing' to 'Learning' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ These methods have been carefully studied and supported in our frameworks:
 </details>
 
 <details open>
-<summary>Internal Learing (click to collapse)</summary>
+<summary>Internal Learning (click to collapse)</summary>
 
 - ✅ [SinGAN](configs/singan/README.md) (ICCV'2019)
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -88,7 +88,7 @@ v0.1.0 在 20/04/2021 发布。 关于细节和发布历史，请参考 [changel
 </details>
 
 <details open>
-<summary>Internal Learing (点击折叠)</summary>
+<summary>Internal Learning (点击折叠)</summary>
 
 - ✅ [SinGAN](configs/dcgan/README.md) (ICCV'2019)
 


### PR DESCRIPTION
There is a typo in the README. This PR changes the word `Learing` to `Learning`.