### PR TITLE
Change math to numpy

### DIFF
--- a/apps/stylegan_projector.py
+++ b/apps/stylegan_projector.py
@@ -5,10 +5,10 @@ r"""
     Ref: https://github.com/rosinality/stylegan2-pytorch/blob/master/projector.py # noqa
 """
 import argparse
-import math
 import os
 
 import mmcv
+import numpy as np
 import torch
 import torch.nn.functional as F
 from mmcv import Config
@@ -124,7 +124,7 @@ def noise_normalize_(noises):
 
 def get_lr(t, initial_lr, rampdown=0.25, rampup=0.05):
     lr_ramp = min(1, (1 - t) / rampdown)
-    lr_ramp = 0.5 - 0.5 * math.cos(lr_ramp * math.pi)
+    lr_ramp = 0.5 - 0.5 * np.cos(lr_ramp * np.pi)
     lr_ramp = lr_ramp * min(1, t / rampup)
     return initial_lr * lr_ramp
 

--- a/mmgen/datasets/samplers/distributed_sampler.py
+++ b/mmgen/datasets/samplers/distributed_sampler.py
@@ -1,6 +1,6 @@
 from __future__ import division
-import math
 
+import numpy as np
 import torch
 from torch.utils.data import DistributedSampler as _DistributedSampler
 
@@ -25,8 +25,10 @@ class DistributedSampler(_DistributedSampler):
         self.samples_per_gpu = samples_per_gpu
         # fix the bug of the official implementation
         self.num_samples_per_replica = int(
-            math.ceil(
-                len(self.dataset) * 1.0 / self.num_replicas / samples_per_gpu))
+            int(
+                np.ceil(
+                    len(self.dataset) * 1.0 / self.num_replicas /
+                    samples_per_gpu)))
         self.num_samples = self.num_samples_per_replica * self.samples_per_gpu
         self.total_size = self.num_samples * self.num_replicas
 
@@ -43,9 +45,10 @@ class DistributedSampler(_DistributedSampler):
             self.samples_per_gpu = samples_per_gpu
         # fix the bug of the official implementation
         self.num_samples_per_replica = int(
-            math.ceil(
-                len(self.dataset) * 1.0 / self.num_replicas /
-                self.samples_per_gpu))
+            int(
+                np.ceil(
+                    len(self.dataset) * 1.0 / self.num_replicas /
+                    self.samples_per_gpu)))
         self.num_samples = self.num_samples_per_replica * self.samples_per_gpu
         self.total_size = self.num_samples * self.num_replicas
 

--- a/mmgen/datasets/singan_dataset.py
+++ b/mmgen/datasets/singan_dataset.py
@@ -1,6 +1,5 @@
-import math
-
 import mmcv
+import numpy as np
 import torch
 from torch.utils.data import Dataset
 
@@ -21,33 +20,36 @@ def create_real_pyramid(real, min_size, max_size, scale_factor_init):
         scale_factor_init (float): The initial scale factor.
     """
 
-    num_scales = math.ceil(
-        math.log(
-            math.pow(min_size / min(real.shape[0], real.shape[1]), 1),
-            scale_factor_init)) + 1
+    num_scales = int(
+        np.ceil(
+            np.log(
+                np.power(min_size / min(real.shape[0], real.shape[1]), 1),
+                scale_factor_init))) + 1
 
-    scale2stop = math.ceil(
-        math.log(
-            min([max_size, max([real.shape[0], real.shape[1]])]) /
-            max([real.shape[0], real.shape[1]]), scale_factor_init))
+    scale2stop = int(
+        np.ceil(
+            np.log(
+                min([max_size, max([real.shape[0], real.shape[1]])]) /
+                max([real.shape[0], real.shape[1]]), scale_factor_init)))
 
     stop_scale = num_scales - scale2stop
 
     scale1 = min(max_size / max([real.shape[0], real.shape[1]]), 1)
     real_max = mmcv.imrescale(real, scale1)
-    scale_factor = math.pow(
+    scale_factor = np.power(
         min_size / (min(real_max.shape[0], real_max.shape[1])),
         1 / (stop_scale))
 
-    scale2stop = math.ceil(
-        math.log(
-            min([max_size, max([real.shape[0], real.shape[1]])]) /
-            max([real.shape[0], real.shape[1]]), scale_factor_init))
+    scale2stop = int(
+        np.ceil(
+            np.log(
+                min([max_size, max([real.shape[0], real.shape[1]])]) /
+                max([real.shape[0], real.shape[1]]), scale_factor_init)))
     stop_scale = num_scales - scale2stop
 
     reals = []
     for i in range(stop_scale + 1):
-        scale = math.pow(scale_factor, stop_scale - i)
+        scale = np.power(scale_factor, stop_scale - i)
         curr_real = mmcv.imrescale(real, scale)
         reals.append(curr_real)
 

--- a/mmgen/models/architectures/dcgan/generator_discriminator.py
+++ b/mmgen/models/architectures/dcgan/generator_discriminator.py
@@ -1,5 +1,4 @@
-import math
-
+import numpy as np
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule, normal_init
@@ -74,7 +73,7 @@ class DCGANGenerator(nn.Module):
         self.noise_size = noise_size
 
         # the number of times for upsampling
-        self.num_upsamples = int(math.log2(output_scale // input_scale))
+        self.num_upsamples = int(np.log2(output_scale // input_scale))
 
         # output 4x4 feature map
         self.noise2feat = ConvModule(
@@ -244,7 +243,7 @@ class DCGANDiscriminator(nn.Module):
         self.base_channels = base_channels
 
         # the number of times for downsampling
-        self.num_downsamples = int(math.log2(input_scale // output_scale))
+        self.num_downsamples = int(np.log2(input_scale // output_scale))
 
         # build up downsampling backbone (excluding the output layer)
         downsamples = []

--- a/mmgen/models/architectures/lsgan/generator_discriminator.py
+++ b/mmgen/models/architectures/lsgan/generator_discriminator.py
@@ -1,5 +1,4 @@
-import math
-
+import numpy as np
 import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule
@@ -74,7 +73,7 @@ class LSGANGenerator(nn.Module):
                 'act', build_activation_layer(default_act_cfg))
 
         # the number of times for upsampling
-        self.num_upsamples = int(math.log2(output_scale // input_scale)) - 2
+        self.num_upsamples = int(np.log2(output_scale // input_scale)) - 2
 
         # build up convolution backbone (excluding the output layer)
         self.conv_blocks = nn.ModuleList()
@@ -254,7 +253,7 @@ class LSGANDiscriminator(nn.Module):
                 act_cfg=default_act_cfg))
 
         # the number of times for downsampling
-        self.num_downsamples = int(math.log2(input_scale // output_scale)) - 1
+        self.num_downsamples = int(np.log2(input_scale // output_scale)) - 1
 
         # build up downsampling backbone (excluding the output layer)
         curr_channels = base_channels

--- a/mmgen/models/architectures/positional_encoding.py
+++ b/mmgen/models/architectures/positional_encoding.py
@@ -1,5 +1,4 @@
-import math
-
+import numpy as np
 import torch
 import torch.nn as nn
 
@@ -68,9 +67,9 @@ class SinusoidalPositionalEmbedding(nn.Module):
         # there is a little difference from the original paper.
         half_dim = embedding_dim // 2
         if not div_half_dim:
-            emb = math.log(10000) / (half_dim - 1)
+            emb = np.log(10000) / (half_dim - 1)
         else:
-            emb = math.log(1e4) / half_dim
+            emb = np.log(1e4) / half_dim
         # compute exp(-log10000 / d * i)
         emb = torch.exp(torch.arange(half_dim, dtype=torch.float) * -emb)
         emb = torch.arange(

--- a/mmgen/models/architectures/singan/generator_discriminator.py
+++ b/mmgen/models/architectures/singan/generator_discriminator.py
@@ -1,6 +1,6 @@
-import math
 from functools import partial
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -65,9 +65,10 @@ class SinGANMultiScaleGenerator(nn.Module):
             F.interpolate, mode='bicubic', align_corners=True)
 
         for scale in range(num_scales + 1):
-            base_ch = min(base_channels * pow(2, math.floor(scale / 4)), 128)
+            base_ch = min(base_channels * pow(2, int(np.floor(scale / 4))),
+                          128)
             min_feat_ch = min(
-                min_feat_channels * pow(2, math.floor(scale / 4)), 128)
+                min_feat_channels * pow(2, int(np.floor(scale / 4))), 128)
 
             self.blocks.append(
                 GeneratorBlock(
@@ -218,9 +219,10 @@ class SinGANMultiScaleDiscriminator(nn.Module):
         super().__init__()
         self.blocks = nn.ModuleList()
         for scale in range(num_scales + 1):
-            base_ch = min(base_channels * pow(2, math.floor(scale / 4)), 128)
+            base_ch = min(base_channels * pow(2, int(np.floor(scale / 4))),
+                          128)
             min_feat_ch = min(
-                min_feat_channels * pow(2, math.floor(scale / 4)), 128)
+                min_feat_channels * pow(2, int(np.floor(scale / 4))), 128)
             self.blocks.append(
                 DiscriminatorBlock(
                     in_channels=in_channels,

--- a/mmgen/models/architectures/singan/positional_encoding.py
+++ b/mmgen/models/architectures/singan/positional_encoding.py
@@ -4,10 +4,10 @@ In this module, we provide necessary components to conduct experiments
 mentioned in the paper: Positional Encoding as Spatial Inductive Bias in GANs.
 More details can be found in: https://arxiv.org/pdf/2012.05217.pdf
 """
-import math
 from functools import partial
 
 import mmcv
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -97,9 +97,10 @@ class SinGANMSGeneratorPE(SinGANMultiScaleGenerator):
             F.interpolate, mode='bicubic', align_corners=True)
 
         for scale in range(num_scales + 1):
-            base_ch = min(base_channels * pow(2, math.floor(scale / 4)), 128)
+            base_ch = min(base_channels * pow(2, int(np.floor(scale / 4))),
+                          128)
             min_feat_ch = min(
-                min_feat_channels * pow(2, math.floor(scale / 4)), 128)
+                min_feat_channels * pow(2, int(np.floor(scale / 4))), 128)
 
             if scale == 0:
                 in_ch = (

--- a/mmgen/models/architectures/stylegan/generator_discriminator_v1.py
+++ b/mmgen/models/architectures/stylegan/generator_discriminator_v1.py
@@ -1,7 +1,7 @@
-import math
 import random
 
 import mmcv
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -90,7 +90,7 @@ class StyleGANv1Generator(nn.Module):
         }
 
         # generator backbone (8x8 --> higher resolutions)
-        self.log_size = int(math.log2(self.out_size))
+        self.log_size = int(np.log2(self.out_size))
 
         self.convs = nn.ModuleList()
         self.to_rgbs = nn.ModuleList()
@@ -332,7 +332,7 @@ class StyleGANv1Generator(nn.Module):
             latent = torch.cat([latent, latent2], 1)
 
         curr_log_size = self.log_size if curr_scale < 0 else int(
-            math.log2(curr_scale))
+            np.log2(curr_scale))
         step = curr_log_size - 2
 
         _index = 0
@@ -408,7 +408,7 @@ class StyleGAN1Discriminator(nn.Module):
             1024: 16,
         }
 
-        log_size = int(math.log2(in_size))
+        log_size = int(np.log2(in_size))
         self.log_size = log_size
         in_channels = channels[in_size]
 
@@ -495,7 +495,7 @@ class StyleGAN1Discriminator(nn.Module):
             torch.Tensor: Predict score for the input image.
         """
         curr_log_size = self.log_size if curr_scale < 0 else int(
-            math.log2(curr_scale))
+            np.log2(curr_scale))
         step = curr_log_size - 2
         for i in range(step, -1, -1):
             index = self.n_layer - i - 1

--- a/mmgen/models/architectures/stylegan/generator_discriminator_v2.py
+++ b/mmgen/models/architectures/stylegan/generator_discriminator_v2.py
@@ -1,7 +1,7 @@
-import math
 import random
 
 import mmcv
+import numpy as np
 import torch
 import torch.nn as nn
 from mmcv.runner.checkpoint import _load_checkpoint_with_prefix
@@ -136,7 +136,7 @@ class StyleGANv2Generator(nn.Module):
             self.channels[4], style_channels, upsample=False)
 
         # generator backbone (8x8 --> higher resolutions)
-        self.log_size = int(math.log2(self.out_size))
+        self.log_size = int(np.log2(self.out_size))
 
         self.convs = nn.ModuleList()
         self.upsamples = nn.ModuleList()
@@ -486,7 +486,7 @@ class StyleGAN2Discriminator(nn.Module):
             1024: 16 * channel_multiplier,
         }
 
-        log_size = int(math.log2(in_size))
+        log_size = int(np.log2(in_size))
 
         in_channels = channels[in_size]
 

--- a/mmgen/models/architectures/stylegan/modules/styleganv2_modules.py
+++ b/mmgen/models/architectures/stylegan/modules/styleganv2_modules.py
@@ -1,8 +1,8 @@
-import math
 from copy import deepcopy
 from functools import partial
 
 import mmcv
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -951,7 +951,7 @@ class ResBlock(nn.Module):
         out = self.conv2(out)
 
         skip = self.skip(input)
-        out = (out + skip) / math.sqrt(2)
+        out = (out + skip) / np.sqrt(2)
 
         return out
 

--- a/mmgen/models/architectures/stylegan/mspie.py
+++ b/mmgen/models/architectures/stylegan/mspie.py
@@ -1,8 +1,8 @@
-import math
 import random
 from copy import deepcopy
 
 import mmcv
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -138,7 +138,7 @@ class MSStyleGANv2Generator(nn.Module):
             self.channels[4], style_channels, upsample=False)
 
         # generator backbone (8x8 --> higher resolutions)
-        self.log_size = int(math.log2(self.out_size))
+        self.log_size = int(np.log2(self.out_size))
 
         self.convs = nn.ModuleList()
         self.upsamples = nn.ModuleList()
@@ -505,7 +505,7 @@ class MSStyleGAN2Discriminator(nn.Module):
             1024: 16 * channel_multiplier,
         }
 
-        log_size = int(math.log2(in_size))
+        log_size = int(np.log2(in_size))
         in_channels = channels[in_size]
         convs = [ConvDownLayer(3, channels[in_size], 1)]
 

--- a/mmgen/models/losses/gen_auxiliary_loss.py
+++ b/mmgen/models/losses/gen_auxiliary_loss.py
@@ -1,5 +1,4 @@
-import math
-
+import numpy as np
 import torch
 import torch.autograd as autograd
 import torch.distributed as dist
@@ -57,7 +56,7 @@ def gen_path_regularizer(generator,
     output_dict = generator(None, num_batches=num_batches, return_latents=True)
     fake_img, latents = output_dict['fake_img'], output_dict['latent']
 
-    noise = torch.randn_like(fake_img) / math.sqrt(
+    noise = torch.randn_like(fake_img) / np.sqrt(
         fake_img.shape[2] * fake_img.shape[3])
 
     grad = autograd.grad(

--- a/mmgen/models/misc.py
+++ b/mmgen/models/misc.py
@@ -1,5 +1,3 @@
-import math
-
 import numpy as np
 import torch
 from torchvision.utils import make_grid
@@ -53,7 +51,7 @@ def tensor2img(tensor, out_type=np.uint8, min_max=(0, 1)):
         n_dim = _tensor.dim()
         if n_dim == 4:
             img_np = make_grid(
-                _tensor, nrow=int(math.sqrt(_tensor.size(0))),
+                _tensor, nrow=int(np.sqrt(_tensor.size(0))),
                 normalize=False).numpy()
             img_np = np.transpose(img_np[[2, 1, 0], :, :], (1, 2, 0))
         elif n_dim == 3:

--- a/tests/test_models/test_pggan.py
+++ b/tests/test_models/test_pggan.py
@@ -1,6 +1,6 @@
-import math
 from copy import deepcopy
 
+import numpy as np
 import pytest
 import torch
 import torch.nn as nn
@@ -69,24 +69,21 @@ class TestPGGAN:
                 assert results['fake_imgs'].shape == (3, 3, 4, 4)
             elif iter_num == 2:
                 assert results['fake_imgs'].shape == (3, 3, 8, 8)
-                assert math.isclose(
-                    pggan._actual_nkimgs[0], 0.006, abs_tol=1e-8)
+                assert np.isclose(pggan._actual_nkimgs[0], 0.006, atol=1e-8)
             elif iter_num == 3:
                 assert results['fake_imgs'].shape == (3, 3, 8, 8)
-                assert math.isclose(
-                    pggan._actual_nkimgs[0], 0.006, abs_tol=1e-8)
-                assert math.isclose(
+                assert np.isclose(pggan._actual_nkimgs[0], 0.006, atol=1e-8)
+                assert np.isclose(
                     pggan.optimizer['generator'].defaults['lr'],
                     0.0001,
-                    abs_tol=1e-8)
+                    atol=1e-8)
             elif iter_num == 5:
                 assert results['fake_imgs'].shape == (3, 3, 16, 16)
-                assert math.isclose(
-                    pggan._actual_nkimgs[-1], 0.012, abs_tol=1e-8)
-                assert math.isclose(
+                assert np.isclose(pggan._actual_nkimgs[-1], 0.012, atol=1e-8)
+                assert np.isclose(
                     pggan.optimizer['generator'].defaults['lr'],
                     0.00005,
-                    abs_tol=1e-8)
+                    atol=1e-8)
 
         # test sample from noise
         outputs = pggan.sample_from_noise(None, num_batches=2)
@@ -146,8 +143,7 @@ class TestPGGAN:
                 assert results['fake_imgs'].shape == (3, 3, 4, 4)
             elif iter_num == 2:
                 assert results['fake_imgs'].shape == (3, 3, 8, 8)
-                assert math.isclose(
-                    pggan._actual_nkimgs[0], 0.006, abs_tol=1e-8)
+                assert np.isclose(pggan._actual_nkimgs[0], 0.006, atol=1e-8)
 
         train_cfg_ = deepcopy(self.train_cfg)
         train_cfg_['optimizer_cfg'] = dict(
@@ -189,13 +185,10 @@ class TestPGGAN:
                 assert results['fake_imgs'].shape == (3, 3, 4, 4)
             elif iter_num == 2:
                 assert results['fake_imgs'].shape == (3, 3, 8, 8)
-                assert math.isclose(
-                    pggan._actual_nkimgs[0], 0.006, abs_tol=1e-8)
+                assert np.isclose(pggan._actual_nkimgs[0], 0.006, atol=1e-8)
             elif iter_num == 3:
                 assert results['fake_imgs'].shape == (3, 3, 8, 8)
-                assert math.isclose(
-                    pggan._actual_nkimgs[0], 0.006, abs_tol=1e-8)
+                assert np.isclose(pggan._actual_nkimgs[0], 0.006, atol=1e-8)
             elif iter_num == 5:
                 assert results['fake_imgs'].shape == (3, 3, 16, 16)
-                assert math.isclose(
-                    pggan._actual_nkimgs[-1], 0.012, abs_tol=1e-8)
+                assert np.isclose(pggan._actual_nkimgs[-1], 0.012, atol=1e-8)

--- a/tests/test_models/test_stylegan1.py
+++ b/tests/test_models/test_stylegan1.py
@@ -1,5 +1,4 @@
-import math
-
+import numpy as np
 import pytest
 import torch
 
@@ -60,14 +59,12 @@ class TestStyleGANV1:
                 assert results['fake_imgs'].shape == (3, 3, 8, 8)
             elif iter_num == 2:
                 assert results['fake_imgs'].shape == (3, 3, 16, 16)
-                assert math.isclose(
-                    stylegan._actual_nkimgs[0], 0.006, abs_tol=1e-8)
+                assert np.isclose(stylegan._actual_nkimgs[0], 0.006, atol=1e-8)
             elif iter_num == 3:
                 assert results['fake_imgs'].shape == (3, 3, 16, 16)
             elif iter_num == 4:
                 assert results['fake_imgs'].shape == (3, 3, 32, 32)
-                assert math.isclose(
-                    stylegan._actual_nkimgs[1], 0.012, abs_tol=1e-8)
+                assert np.isclose(stylegan._actual_nkimgs[1], 0.012, atol=1e-8)
 
     def test_stylegan1_cpu(self):
         # test default config
@@ -85,11 +82,9 @@ class TestStyleGANV1:
                 assert results['fake_imgs'].shape == (3, 3, 8, 8)
             elif iter_num == 2:
                 assert results['fake_imgs'].shape == (3, 3, 16, 16)
-                assert math.isclose(
-                    stylegan._actual_nkimgs[0], 0.006, abs_tol=1e-8)
+                assert np.isclose(stylegan._actual_nkimgs[0], 0.006, atol=1e-8)
             elif iter_num == 3:
                 assert results['fake_imgs'].shape == (3, 3, 16, 16)
             elif iter_num == 4:
                 assert results['fake_imgs'].shape == (3, 3, 32, 32)
-                assert math.isclose(
-                    stylegan._actual_nkimgs[1], 0.012, abs_tol=1e-8)
+                assert np.isclose(stylegan._actual_nkimgs[1], 0.012, atol=1e-8)


### PR DESCRIPTION
This PR changes the use of the package `math` to `numpy`. The detailed changes are as follows:

1. `math.log2(...)` -> `np.log2(...)`
2. `math.cos(...)` -> `np.cos(...)`
3. `math.pi` -> `np.pi`
4. `math.ceil(...)` -> `int(np.ceil(...))`
5. `math.log(...)` -> `np.log(...)`
6. `math.pow(...)` -> `np.power(...)`
7. `math.sqrt(...)` -> `np.sqrt(...)`
8. `math.floor(...)` -> `int(np.floor(...))`
9. `math.isclose(..., abs_tol=...)` -> `np.isclose(..., atol=...)`