### PR TITLE
[Enhancement] Remove conv_cfg argument in dcgan

### DIFF
--- a/mmgen/models/architectures/dcgan/generator_discriminator.py
+++ b/mmgen/models/architectures/dcgan/generator_discriminator.py
@@ -42,8 +42,6 @@ class DCGANGenerator(nn.Module):
             convolutional feature, respectively. Defaults to 4.
         noise_size (int, optional): Size of the input noise
             vector. Defaults to 100.
-        conv_cfg (dict, optional): Config for the convolution module used in
-            this generator. Defaults to ``dict(type='ConvTranspose2d')``.
         default_norm_cfg (dict, optional): Norm config for all of layers
             except for the final output layer. Defaults to ``dict(type='BN')``.
         default_act_cfg (dict, optional): Activation config for all of layers
@@ -61,7 +59,6 @@ class DCGANGenerator(nn.Module):
                  base_channels=1024,
                  input_scale=4,
                  noise_size=100,
-                 conv_cfg=dict(type='ConvTranspose2d'),
                  default_norm_cfg=dict(type='BN'),
                  default_act_cfg=dict(type='ReLU'),
                  out_act_cfg=dict(type='Tanh'),
@@ -82,7 +79,7 @@ class DCGANGenerator(nn.Module):
             kernel_size=4,
             stride=1,
             padding=0,
-            conv_cfg=conv_cfg,
+            conv_cfg=dict(type='ConvTranspose2d'),
             norm_cfg=default_norm_cfg,
             act_cfg=default_act_cfg)
 
@@ -97,7 +94,7 @@ class DCGANGenerator(nn.Module):
                     kernel_size=4,
                     stride=2,
                     padding=1,
-                    conv_cfg=conv_cfg,
+                    conv_cfg=dict(type='ConvTranspose2d'),
                     norm_cfg=default_norm_cfg,
                     act_cfg=default_act_cfg))
 
@@ -112,7 +109,7 @@ class DCGANGenerator(nn.Module):
             kernel_size=4,
             stride=2,
             padding=1,
-            conv_cfg=conv_cfg,
+            conv_cfg=dict(type='ConvTranspose2d'),
             norm_cfg=None,
             act_cfg=out_act_cfg)
 
@@ -212,8 +209,6 @@ class DCGANDiscriminator(nn.Module):
         base_channels (int, optional): The basic channel number of the
             generator. The other layers contains channels based on this number.
             Defaults to 128.
-        conv_cfg (dict, optional): Config for the convolution module used in
-            this discriminator. Defaults to dict(type='Conv2d').
         default_norm_cfg (dict, optional): Norm config for all of layers
             except for the final output layer. Defaults to ``dict(type='BN')``.
         default_act_cfg (dict, optional): Activation config for all of layers
@@ -231,7 +226,6 @@ class DCGANDiscriminator(nn.Module):
                  out_channels,
                  in_channels=3,
                  base_channels=128,
-                 conv_cfg=dict(type='Conv2d'),
                  default_norm_cfg=dict(type='BN'),
                  default_act_cfg=dict(type='LeakyReLU'),
                  out_act_cfg=None,
@@ -259,7 +253,7 @@ class DCGANDiscriminator(nn.Module):
                     kernel_size=4,
                     stride=2,
                     padding=1,
-                    conv_cfg=conv_cfg,
+                    conv_cfg=dict(type='Conv2d'),
                     norm_cfg=norm_cfg_,
                     act_cfg=default_act_cfg))
             curr_channels = base_channels * 2**i
@@ -273,7 +267,7 @@ class DCGANDiscriminator(nn.Module):
             kernel_size=4,
             stride=1,
             padding=0,
-            conv_cfg=conv_cfg,
+            conv_cfg=dict(type='Conv2d'),
             norm_cfg=None,
             act_cfg=out_act_cfg)
 


### PR DESCRIPTION
Since `conv_cfg` cannot make any difference easily, we just remove this argument for clear and simple usage.