### PR TITLE
[Feature] Release a benchmark for BigGAN/BigGAN-Deep

### DIFF
--- a/configs/_base_/models/biggan-deep_128x128_cvt_hugging-face_rgb.py
+++ b/configs/_base_/models/biggan-deep_128x128_cvt_hugging-face_rgb.py
@@ -13,7 +13,7 @@ model = dict(
         act_cfg=dict(type='ReLU', inplace=True),
         concat_noise=True,
         auto_sync_bn=False,
-	rgb2bgr=True),
+        rgb2bgr=True),
     discriminator=dict(
         type='BigGANDeepDiscriminator',
         input_scale=128,

--- a/configs/_base_/models/biggan-deep_128x128_cvt_hugging-face_rgb.py
+++ b/configs/_base_/models/biggan-deep_128x128_cvt_hugging-face_rgb.py
@@ -1,0 +1,33 @@
+model = dict(
+    type='BasiccGAN',
+    generator=dict(
+        type='BigGANDeepGenerator',
+        output_scale=128,
+        noise_size=128,
+        num_classes=1000,
+        base_channels=128,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        concat_noise=True,
+        auto_sync_bn=False,
+	rgb2bgr=True),
+    discriminator=dict(
+        type='BigGANDeepDiscriminator',
+        input_scale=128,
+        num_classes=1000,
+        base_channels=128,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True),
+    gan_loss=dict(type='GANLoss', gan_type='hinge'))
+
+train_cfg = dict(
+    disc_steps=8, gen_steps=1, batch_accumulation_steps=8, use_ema=True)
+test_cfg = None
+optimizer = dict(
+    generator=dict(type='Adam', lr=0.0001, betas=(0.0, 0.999), eps=1e-6),
+    discriminator=dict(type='Adam', lr=0.0004, betas=(0.0, 0.999), eps=1e-6))

--- a/configs/_base_/models/biggan-deep_256x256_cvt_hugging-face_rgb.py
+++ b/configs/_base_/models/biggan-deep_256x256_cvt_hugging-face_rgb.py
@@ -13,7 +13,7 @@ model = dict(
         act_cfg=dict(type='ReLU', inplace=True),
         concat_noise=True,
         auto_sync_bn=False,
-	rgb2bgr=True),
+        rgb2bgr=True),
     discriminator=dict(
         type='BigGANDeepDiscriminator',
         input_scale=256,

--- a/configs/_base_/models/biggan-deep_256x256_cvt_hugging-face_rgb.py
+++ b/configs/_base_/models/biggan-deep_256x256_cvt_hugging-face_rgb.py
@@ -1,0 +1,33 @@
+model = dict(
+    type='BasiccGAN',
+    generator=dict(
+        type='BigGANDeepGenerator',
+        output_scale=256,
+        noise_size=128,
+        num_classes=1000,
+        base_channels=128,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        concat_noise=True,
+        auto_sync_bn=False,
+	rgb2bgr=True),
+    discriminator=dict(
+        type='BigGANDeepDiscriminator',
+        input_scale=256,
+        num_classes=1000,
+        base_channels=128,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True),
+    gan_loss=dict(type='GANLoss', gan_type='hinge'))
+
+train_cfg = dict(
+    disc_steps=8, gen_steps=1, batch_accumulation_steps=8, use_ema=True)
+test_cfg = None
+optimizer = dict(
+    generator=dict(type='Adam', lr=0.0001, betas=(0.0, 0.999), eps=1e-6),
+    discriminator=dict(type='Adam', lr=0.0004, betas=(0.0, 0.999), eps=1e-6))

--- a/configs/_base_/models/biggan-deep_512x512_cvt_hugging-face_rgb.py
+++ b/configs/_base_/models/biggan-deep_512x512_cvt_hugging-face_rgb.py
@@ -13,7 +13,7 @@ model = dict(
         act_cfg=dict(type='ReLU', inplace=True),
         concat_noise=True,
         auto_sync_bn=False,
-	rgb2bgr=True),
+        rgb2bgr=True),
     discriminator=dict(
         type='BigGANDeepDiscriminator',
         input_scale=512,

--- a/configs/_base_/models/biggan-deep_512x512_cvt_hugging-face_rgb.py
+++ b/configs/_base_/models/biggan-deep_512x512_cvt_hugging-face_rgb.py
@@ -1,0 +1,33 @@
+model = dict(
+    type='BasiccGAN',
+    generator=dict(
+        type='BigGANDeepGenerator',
+        output_scale=512,
+        noise_size=128,
+        num_classes=1000,
+        base_channels=128,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        concat_noise=True,
+        auto_sync_bn=False,
+	rgb2bgr=True),
+    discriminator=dict(
+        type='BigGANDeepDiscriminator',
+        input_scale=512,
+        num_classes=1000,
+        base_channels=128,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True),
+    gan_loss=dict(type='GANLoss', gan_type='hinge'))
+
+train_cfg = dict(
+    disc_steps=8, gen_steps=1, batch_accumulation_steps=8, use_ema=True)
+test_cfg = None
+optimizer = dict(
+    generator=dict(type='Adam', lr=0.0001, betas=(0.0, 0.999), eps=1e-6),
+    discriminator=dict(type='Adam', lr=0.0004, betas=(0.0, 0.999), eps=1e-6))

--- a/configs/_base_/models/biggan_128x128.py
+++ b/configs/_base_/models/biggan_128x128.py
@@ -1,0 +1,32 @@
+model = dict(
+    type='BasiccGAN',
+    generator=dict(
+        type='BigGANGenerator',
+        output_scale=128,
+        noise_size=120,
+        num_classes=1000,
+        base_channels=96,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        split_noise=True,
+        auto_sync_bn=False),
+    discriminator=dict(
+        type='BigGANDiscriminator',
+        input_scale=128,
+        num_classes=1000,
+        base_channels=96,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True),
+    gan_loss=dict(type='GANLoss', gan_type='hinge'))
+
+train_cfg = dict(
+    disc_steps=8, gen_steps=1, batch_accumulation_steps=8, use_ema=True)
+test_cfg = None
+optimizer = dict(
+    generator=dict(type='Adam', lr=0.0001, betas=(0.0, 0.999), eps=1e-6),
+    discriminator=dict(type='Adam', lr=0.0004, betas=(0.0, 0.999), eps=1e-6))

--- a/configs/_base_/models/biggan_128x128_cvt_BigGAN-PyTorch_rgb.py
+++ b/configs/_base_/models/biggan_128x128_cvt_BigGAN-PyTorch_rgb.py
@@ -13,7 +13,7 @@ model = dict(
         act_cfg=dict(type='ReLU', inplace=True),
         split_noise=True,
         auto_sync_bn=False,
-	rgb2bgr=True),
+        rgb2bgr=True),
     discriminator=dict(
         type='BigGANDiscriminator',
         input_scale=128,

--- a/configs/_base_/models/biggan_128x128_cvt_BigGAN-PyTorch_rgb.py
+++ b/configs/_base_/models/biggan_128x128_cvt_BigGAN-PyTorch_rgb.py
@@ -1,0 +1,33 @@
+model = dict(
+    type='BasiccGAN',
+    generator=dict(
+        type='BigGANGenerator',
+        output_scale=128,
+        noise_size=120,
+        num_classes=1000,
+        base_channels=96,
+        shared_dim=128,
+        with_shared_embedding=True,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        split_noise=True,
+        auto_sync_bn=False,
+	rgb2bgr=True),
+    discriminator=dict(
+        type='BigGANDiscriminator',
+        input_scale=128,
+        num_classes=1000,
+        base_channels=96,
+        sn_eps=1e-6,
+        init_type='ortho',
+        act_cfg=dict(type='ReLU', inplace=True),
+        with_spectral_norm=True),
+    gan_loss=dict(type='GANLoss', gan_type='hinge'))
+
+train_cfg = dict(
+    disc_steps=8, gen_steps=1, batch_accumulation_steps=8, use_ema=True)
+test_cfg = None
+optimizer = dict(
+    generator=dict(type='Adam', lr=0.0001, betas=(0.0, 0.999), eps=1e-6),
+    discriminator=dict(type='Adam', lr=0.0004, betas=(0.0, 0.999), eps=1e-6))

--- a/configs/biggan/README.md
+++ b/configs/biggan/README.md
@@ -1,0 +1,77 @@
+# LARGE SCALE GAN TRAINING FOR HIGH FIDELITY NATURAL IMAGE SYNTHESIS
+
+## Introduction
+<!-- [ALGORITHM] -->
+```latex
+@inproceedings{
+brock2018large,
+title={Large Scale {GAN} Training for High Fidelity Natural Image Synthesis},
+author={Andrew Brock and Jeff Donahue and Karen Simonyan},
+booktitle={International Conference on Learning Representations},
+year={2019},
+url={https://openreview.net/forum?id=B1xsqj09Fm},
+}
+```
+
+The BigGAN/BigGAN-Deep is a conditional generation model that can generate both high-resolution and high-quality images by scaling up the batch size and number of model parameters. 
+
+We have conducted training BigGAN with CIFAR10(3x32x32) and ImageNet1k(3x128x128) dataset, and the sampling results are showed below
+<div align="center">
+  <b> Results from our BigGAN trained in CIFAR10</b>
+  <br/>
+  <img src="https://user-images.githubusercontent.com/22982797/126476913-3ce8e2c8-f189-4caa-90ed-b44e279cb669.png" width="800"/>
+</div>
+
+Evaluation of our trained BIgGAN.
+|    Models    | Dataset |   FID (Iter) | IS (Iter) | Config |  Download  |
+|:------------:|:-------:|:--------------:|:---------------:|:------:|:----------:|
+| BigGAN 32x32 | CIFAR10 |     9.78(390000)           |       8.70(390000)          | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/biggan/biggan_cifar10_32x32_b25x2_500k.py) | [model](https://download.openmmlab.com/mmgen/biggan/biggan_cifar10_32x32_b25x2_500k_20210728_110906-08b61a44.pth)\|[log](https://download.openmmlab.com/mmgen/biggan/biggan_cifar10_32_b25x2_500k_20210706_171051.log.json) |
+| BigGAN 128x128 | ImageNet1k |       12.32(1150000)         |         72.7(1150000)        | [config](https://github.com/open-mmlab/mmgeneration/blob/master/) | [model](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_b32x8_1150k_20210730_124753-b14026b7.pth)\|[log](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_b32x8_1500k_20210726_224316.log.json) |
+
+Note: This is an earlier version(1150k iter) of BigGAN trained on ImageNet1k, the model with best performance is still on the way.
+
+## converted weights
+Since we havn't finished training our models, we provide you with several pre-trained weights which has already be evaluated. Here, we refer to [BigGAN-PyTorch](https://github.com/ajbrock/BigGAN-PyTorch) and [pytorch-pretrained-BigGAN](https://github.com/huggingface/pytorch-pretrained-BigGAN).
+
+Evaluation results and download links are provided below.
+
+|        Models       |   Dataset  | FID | IS | Config | Download | Original Download link |
+|:-------------------:|:----------:|:--:|:---:|:------:|:--------:|:----------------------:|
+|    BigGAN 128x128   | ImageNet1k | 10.1414   |  96.728   | [config](https://github.com/open-mmlab/mmgeneration/blob/master/) |   [model](	
+https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_cvt_BigGAN-PyTorch_rgb_20210730_125223-3e353fef.pth)  |          [link](https://drive.google.com/open?id=1nAle7FCVFZdix2--ks0r5JBkFnKw8ctW)          |
+| BigGAN-Deep 128x128 | ImageNet1k |  5.9471  |  107.161   | [config](https://github.com/open-mmlab/mmgeneration/blob/master/) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_128x128_cvt_hugging-face_rgb_20210728_111659-099e96f9.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-128-pytorch_model.bin)          |
+| BigGAN-Deep 256x256 | ImageNet1k | 11.3151   | 135.107    | [config](https://github.com/open-mmlab/mmgeneration/blob/master/) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_256x256_cvt_hugging-face_rgb_20210728_111735-28651569.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-256-pytorch_model.bin)          |
+| BigGAN-Deep 512x512 | ImageNet1k | 16.8728   | 124.368    | [config]() |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_512x512_cvt_hugging-face_rgb_20210728_112346-a42585f2.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-512-pytorch_model.bin)          |
+
+Sampling results are showed below.
+<div align="center">
+  <b> Results from our BigGAN-Deep trained in ImageNet 128x128 with truncation factor 0.4</b>
+  <br/>
+  <img src="https://user-images.githubusercontent.com/22982797/126481730-8da7180b-7b1b-42f0-9bec-78d879b6265b.png" width="800"/>
+</div>
+
+<div align="center">
+  <b> Results from our BigGAN-Deep with Pre-trained weights in ImageNet 256x256 with truncation factor 0.4</b>
+  <br/>
+  <img src="https://user-images.githubusercontent.com/22982797/126486040-64effa29-959e-4e43-bcae-15925a2e0599.png" width="800"/>
+</div>
+
+<div align="center">
+  <b> Results from our BigGAN-Deep with Pre-trained weights in ImageNet 512x512 truncation factor 0.4</b>
+  <br/>
+  <img src="https://user-images.githubusercontent.com/22982797/126487428-50101454-59cb-469d-a1f1-36ffb6291582.png" width="800"/>
+</div>
+Above sampling with truncation trick can be performed by command below
+
+```python
+python demo/conditional_demo.py CONFIG_PATH CKPT_PATH --sample-cfg truncation=0.4 # set truncation value as you want
+```
+
+## Interpolation
+
+We will also provide script for image interpolation of conditional models soon.
+<div align="center">
+  <b> Image interpolating Results of our BigGAN-Deep</b>
+  <br/>
+  <img src="https://user-images.githubusercontent.com/22982797/126580403-2baa987b-ff55-4fb5-a53a-b08e8a6a72a2.png" width="800"/>
+</div>

--- a/configs/biggan/README.md
+++ b/configs/biggan/README.md
@@ -13,9 +13,9 @@ url={https://openreview.net/forum?id=B1xsqj09Fm},
 }
 ```
 
-The BigGAN/BigGAN-Deep is a conditional generation model that can generate both high-resolution and high-quality images by scaling up the batch size and number of model parameters.
+The `BigGAN/BigGAN-Deep` is a conditional generation model that can generate both high-resolution and high-quality images by scaling up the batch size and the number of model parameters.
 
-We have conducted training BigGAN with CIFAR10(3x32x32) and ImageNet1k(3x128x128) dataset, and the sampling results are showed below.
+We have finished training `BigGAN` in `Cifar10` (32x32) and are aligning training performance in `ImageNet1k` (128x128). Some sampled results are shown below for your reference.
 <div align="center">
   <b> Results from our BigGAN trained in CIFAR10</b>
   <br/>
@@ -34,10 +34,10 @@ Evaluation of our trained BIgGAN.
 | BigGAN 32x32 | CIFAR10 |     9.78(390000)           |       8.70(390000)          | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/biggan/biggan_cifar10_32x32_b25x2_500k.py) | [model](https://download.openmmlab.com/mmgen/biggan/biggan_cifar10_32x32_b25x2_500k_20210728_110906-08b61a44.pth)\|[log](https://download.openmmlab.com/mmgen/biggan/biggan_cifar10_32_b25x2_500k_20210706_171051.log.json) |
 | BigGAN 128x128 | ImageNet1k |       12.32(1150000)         |         72.7(1150000)        | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/biggan/biggan_imagenet1k_128x128_b32x8_1500k.py) | [model](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_b32x8_1150k_20210730_124753-b14026b7.pth)\|[log](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_b32x8_1500k_20210726_224316.log.json) |
 
-Note: This is an earlier version(1150k iter) of BigGAN trained on `ImageNet1k`, the model with best performance is still on the way.
+Note: This is an unfinished version (1150k iter) of BigGAN trained on `ImageNet1k`. The model with the best performance is still on the way.
 
-## converted weights
-Since we havn't finished training our models, we provide you with several pre-trained weights which has already be evaluated. Here, we refer to [BigGAN-PyTorch](https://github.com/ajbrock/BigGAN-PyTorch) and [pytorch-pretrained-BigGAN](https://github.com/huggingface/pytorch-pretrained-BigGAN).
+## Converted weights
+Since we havn't finished training our models, we provide you with several pre-trained weights which have been evaluated. Here, we refer to [BigGAN-PyTorch](https://github.com/ajbrock/BigGAN-PyTorch) and [pytorch-pretrained-BigGAN](https://github.com/huggingface/pytorch-pretrained-BigGAN).
 
 Evaluation results and download links are provided below.
 
@@ -48,7 +48,7 @@ Evaluation results and download links are provided below.
 | BigGAN-Deep 256x256 | ImageNet1k | 11.3151   | 135.107    | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/_base_/models/biggan-deep_256x256_cvt_hugging-face_rgb.py) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_256x256_cvt_hugging-face_rgb_20210728_111735-28651569.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-256-pytorch_model.bin)          |
 | BigGAN-Deep 512x512 | ImageNet1k | 16.8728   | 124.368    | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/_base_/models/biggan-deep_512x512_cvt_hugging-face_rgb.py) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_512x512_cvt_hugging-face_rgb_20210728_112346-a42585f2.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-512-pytorch_model.bin)          |
 
-Sampling results are showed below.
+Sampling results are shown below.
 <div align="center">
   <b> Results from our BigGAN-Deep with Pre-trained weights in ImageNet 128x128 with truncation factor 0.4</b>
   <br/>
@@ -66,12 +66,18 @@ Sampling results are showed below.
   <br/>
   <img src="https://user-images.githubusercontent.com/22982797/126487428-50101454-59cb-469d-a1f1-36ffb6291582.png" width="800"/>
 </div>
-Above sampling with truncation trick can be performed by command below
+Sampling with truncation trick above can be performed by command below.
 
 ```python
 python demo/conditional_demo.py CONFIG_PATH CKPT_PATH --sample-cfg truncation=0.4 # set truncation value as you want
 ```
-
+For converted weights, we provide model configs under `configs/_base_/models` listed as follows:
+```python
+# biggan_128x128_cvt_BigGAN-PyTorch_rgb.py
+# biggan-deep_128x128_cvt_hugging-face_rgb.py
+# biggan-deep_256x256_cvt_hugging-face_rgb.py
+# biggan-deep_512x512_cvt_hugging-face_rgb.py
+```
 ## Interpolation
 
 We will also provide script for image interpolation of conditional models soon.

--- a/configs/biggan/README.md
+++ b/configs/biggan/README.md
@@ -13,22 +13,28 @@ url={https://openreview.net/forum?id=B1xsqj09Fm},
 }
 ```
 
-The BigGAN/BigGAN-Deep is a conditional generation model that can generate both high-resolution and high-quality images by scaling up the batch size and number of model parameters. 
+The BigGAN/BigGAN-Deep is a conditional generation model that can generate both high-resolution and high-quality images by scaling up the batch size and number of model parameters.
 
-We have conducted training BigGAN with CIFAR10(3x32x32) and ImageNet1k(3x128x128) dataset, and the sampling results are showed below
+We have conducted training BigGAN with CIFAR10(3x32x32) and ImageNet1k(3x128x128) dataset, and the sampling results are showed below.
 <div align="center">
   <b> Results from our BigGAN trained in CIFAR10</b>
   <br/>
   <img src="https://user-images.githubusercontent.com/22982797/126476913-3ce8e2c8-f189-4caa-90ed-b44e279cb669.png" width="800"/>
 </div>
 
+<div align="center">
+  <b> Results from our BigGAN trained in ImageNet</b>
+  <br/>
+  <img src="https://user-images.githubusercontent.com/22982797/127615534-6278ce1b-5cff-4189-83c6-9ecc8de08dfc.png" width="800"/>
+</div>
+
 Evaluation of our trained BIgGAN.
 |    Models    | Dataset |   FID (Iter) | IS (Iter) | Config |  Download  |
 |:------------:|:-------:|:--------------:|:---------------:|:------:|:----------:|
 | BigGAN 32x32 | CIFAR10 |     9.78(390000)           |       8.70(390000)          | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/biggan/biggan_cifar10_32x32_b25x2_500k.py) | [model](https://download.openmmlab.com/mmgen/biggan/biggan_cifar10_32x32_b25x2_500k_20210728_110906-08b61a44.pth)\|[log](https://download.openmmlab.com/mmgen/biggan/biggan_cifar10_32_b25x2_500k_20210706_171051.log.json) |
-| BigGAN 128x128 | ImageNet1k |       12.32(1150000)         |         72.7(1150000)        | [config](https://github.com/open-mmlab/mmgeneration/blob/master/) | [model](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_b32x8_1150k_20210730_124753-b14026b7.pth)\|[log](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_b32x8_1500k_20210726_224316.log.json) |
+| BigGAN 128x128 | ImageNet1k |       12.32(1150000)         |         72.7(1150000)        | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/biggan/biggan_imagenet1k_128x128_b32x8_1500k.py) | [model](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_b32x8_1150k_20210730_124753-b14026b7.pth)\|[log](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_b32x8_1500k_20210726_224316.log.json) |
 
-Note: This is an earlier version(1150k iter) of BigGAN trained on ImageNet1k, the model with best performance is still on the way.
+Note: This is an earlier version(1150k iter) of BigGAN trained on `ImageNet1k`, the model with best performance is still on the way.
 
 ## converted weights
 Since we havn't finished training our models, we provide you with several pre-trained weights which has already be evaluated. Here, we refer to [BigGAN-PyTorch](https://github.com/ajbrock/BigGAN-PyTorch) and [pytorch-pretrained-BigGAN](https://github.com/huggingface/pytorch-pretrained-BigGAN).
@@ -37,15 +43,14 @@ Evaluation results and download links are provided below.
 
 |        Models       |   Dataset  | FID | IS | Config | Download | Original Download link |
 |:-------------------:|:----------:|:--:|:---:|:------:|:--------:|:----------------------:|
-|    BigGAN 128x128   | ImageNet1k | 10.1414   |  96.728   | [config](https://github.com/open-mmlab/mmgeneration/blob/master/) |   [model](	
-https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_cvt_BigGAN-PyTorch_rgb_20210730_125223-3e353fef.pth)  |          [link](https://drive.google.com/open?id=1nAle7FCVFZdix2--ks0r5JBkFnKw8ctW)          |
-| BigGAN-Deep 128x128 | ImageNet1k |  5.9471  |  107.161   | [config](https://github.com/open-mmlab/mmgeneration/blob/master/) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_128x128_cvt_hugging-face_rgb_20210728_111659-099e96f9.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-128-pytorch_model.bin)          |
-| BigGAN-Deep 256x256 | ImageNet1k | 11.3151   | 135.107    | [config](https://github.com/open-mmlab/mmgeneration/blob/master/) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_256x256_cvt_hugging-face_rgb_20210728_111735-28651569.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-256-pytorch_model.bin)          |
-| BigGAN-Deep 512x512 | ImageNet1k | 16.8728   | 124.368    | [config]() |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_512x512_cvt_hugging-face_rgb_20210728_112346-a42585f2.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-512-pytorch_model.bin)          |
+|    BigGAN 128x128   | ImageNet1k | 10.1414   |  96.728   | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/_base_/models/biggan_128x128_cvt_BigGAN-PyTorch_rgb.py) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan_imagenet1k_128x128_cvt_BigGAN-PyTorch_rgb_20210730_125223-3e353fef.pth)  |          [link](https://drive.google.com/open?id=1nAle7FCVFZdix2--ks0r5JBkFnKw8ctW)          |
+| BigGAN-Deep 128x128 | ImageNet1k |  5.9471  |  107.161   | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/_base_/models/biggan-deep_128x128_cvt_hugging-face_rgb.py) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_128x128_cvt_hugging-face_rgb_20210728_111659-099e96f9.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-128-pytorch_model.bin)          |
+| BigGAN-Deep 256x256 | ImageNet1k | 11.3151   | 135.107    | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/_base_/models/biggan-deep_256x256_cvt_hugging-face_rgb.py) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_256x256_cvt_hugging-face_rgb_20210728_111735-28651569.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-256-pytorch_model.bin)          |
+| BigGAN-Deep 512x512 | ImageNet1k | 16.8728   | 124.368    | [config](https://github.com/open-mmlab/mmgeneration/blob/master/configs/_base_/models/biggan-deep_512x512_cvt_hugging-face_rgb.py) |   [model](https://download.openmmlab.com/mmgen/biggan/biggan-deep_imagenet1k_512x512_cvt_hugging-face_rgb_20210728_112346-a42585f2.pth)  |          [link](https://s3.amazonaws.com/models.huggingface.co/biggan/biggan-deep-512-pytorch_model.bin)          |
 
 Sampling results are showed below.
 <div align="center">
-  <b> Results from our BigGAN-Deep trained in ImageNet 128x128 with truncation factor 0.4</b>
+  <b> Results from our BigGAN-Deep with Pre-trained weights in ImageNet 128x128 with truncation factor 0.4</b>
   <br/>
   <img src="https://user-images.githubusercontent.com/22982797/126481730-8da7180b-7b1b-42f0-9bec-78d879b6265b.png" width="800"/>
 </div>

--- a/configs/biggan/biggan_imagenet1k_128x128_b32x8_1500k.py
+++ b/configs/biggan/biggan_imagenet1k_128x128_b32x8_1500k.py
@@ -1,0 +1,62 @@
+_base_ = [
+    '../_base_/models/biggan_128x128.py',
+    '../_base_/datasets/imagenet_noaug_128.py', '../_base_/default_runtime.py'
+]
+
+# define dataset
+# you must set `samples_per_gpu`
+data = dict(samples_per_gpu=32, workers_per_gpu=8)
+
+# adjust running config
+lr_config = None
+checkpoint_config = dict(interval=5000, by_epoch=False, max_keep_ckpts=10)
+custom_hooks = [
+    dict(
+        type='VisualizeUnconditionalSamples',
+        output_dir='training_samples',
+        interval=10000),
+    dict(
+        type='ExponentialMovingAverageHook',
+        module_keys=('generator_ema', ),
+        interval=8,
+        start_iter=160000,
+        interp_cfg=dict(momentum=0.9999),
+        priority='VERY_HIGH')
+]
+
+# Traning sets' datasize 1,281,167
+total_iters = 1500000
+
+# use ddp wrapper for faster training
+use_ddp_wrapper = True
+find_unused_parameters = False
+
+runner = dict(
+    type='DynamicIterBasedRunner',
+    is_dynamic_ddp=False,  # Note that this flag should be False.
+    pass_training_status=True)
+
+# Note set your inception_pkl's path
+inception_pkl = "work_dirs/inception_pkl/imagenet.pkl"
+evaluation = dict(
+    type='GenerativeEvalHook',
+    interval=10000,
+    metrics=[
+        dict(
+            type='FID',
+            num_images=50000,
+            inception_pkl=inception_pkl,
+            bgr2rgb=True),
+        dict(type='IS', num_images=50000)
+    ],
+    sample_kwargs=dict(sample_model='ema'),
+    best_metric=['fid', 'is'])
+
+metrics = dict(
+    fid50k=dict(
+        type='FID',
+        num_images=50000,
+        inception_pkl=inception_pkl,
+        bgr2rgb=True,
+        inception_args=dict(type='StyleGAN')),
+    is50k=dict(type='IS', num_images=50000))

--- a/configs/biggan/biggan_imagenet1k_128x128_b32x8_1500k.py
+++ b/configs/biggan/biggan_imagenet1k_128x128_b32x8_1500k.py
@@ -37,7 +37,7 @@ runner = dict(
     pass_training_status=True)
 
 # Note set your inception_pkl's path
-inception_pkl = "work_dirs/inception_pkl/imagenet.pkl"
+inception_pkl = 'work_dirs/inception_pkl/imagenet.pkl'
 evaluation = dict(
     type='GenerativeEvalHook',
     interval=10000,


### PR DESCRIPTION
1. Provide benchmark with evaluation results and converted weights of BigGAN.
2. Provide corresponding configs for users.
Since training on ImageNet and [conditional model interpolation](https://github.com/open-mmlab/mmgeneration/pull/78) are still ongoing. This benchmark needs further improvement in the future.