### PR TITLE
[Fix] Add soft limit to the maximum number of open file descriptors

### DIFF
--- a/mmgen/datasets/builder.py
+++ b/mmgen/datasets/builder.py
@@ -16,8 +16,9 @@ if platform.system() != 'Windows':
     # https://github.com/pytorch/pytorch/issues/973
     import resource
     rlimit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    base_soft_limit = rlimit[0]
     hard_limit = rlimit[1]
-    soft_limit = min(4096, hard_limit)
+    soft_limit = min(max(4096, base_soft_limit), hard_limit)
     resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 DATASETS = Registry('dataset')


### PR DESCRIPTION
In some servers, the original implementation causes an unacceptable stop in training. Thus, we relax the constraint in resources to avoid being killed by the system.