### PR TITLE
[Feature] Support KLD metric and support evaluation for probabilistic models

### DIFF
--- a/mmgen/core/evaluation/__init__.py
+++ b/mmgen/core/evaluation/__init__.py
@@ -3,12 +3,21 @@ from .eval_hooks import GenerativeEvalHook
 from .evaluation import (make_metrics_table, make_vanilla_dataloader,
                          single_gpu_evaluation, single_gpu_online_evaluation)
 from .metric_utils import slerp
-from .metrics import (IS, MS_SSIM, PR, SWD, GaussianKLD, gaussian_kld, ms_ssim,
+from .metrics import (IS, MS_SSIM, PR, SWD, GaussianKLD, ms_ssim,
                       sliced_wasserstein)
 
 __all__ = [
-    'MS_SSIM', 'SWD', 'ms_ssim', 'sliced_wasserstein', 'single_gpu_evaluation',
-    'single_gpu_online_evaluation', 'PR', 'IS', 'slerp', 'GenerativeEvalHook',
-    'make_metrics_table', 'make_vanilla_dataloader', 'GaussianKLD',
-    'gaussian_kld'
+    'MS_SSIM',
+    'SWD',
+    'ms_ssim',
+    'sliced_wasserstein',
+    'single_gpu_evaluation',
+    'single_gpu_online_evaluation',
+    'PR',
+    'IS',
+    'slerp',
+    'GenerativeEvalHook',
+    'make_metrics_table',
+    'make_vanilla_dataloader',
+    'GaussianKLD',
 ]

--- a/mmgen/core/evaluation/__init__.py
+++ b/mmgen/core/evaluation/__init__.py
@@ -3,10 +3,12 @@ from .eval_hooks import GenerativeEvalHook
 from .evaluation import (make_metrics_table, make_vanilla_dataloader,
                          single_gpu_evaluation, single_gpu_online_evaluation)
 from .metric_utils import slerp
-from .metrics import IS, MS_SSIM, PR, SWD, ms_ssim, sliced_wasserstein
+from .metrics import (IS, MS_SSIM, PR, SWD, GaussianKLD, gaussian_kld, ms_ssim,
+                      sliced_wasserstein)
 
 __all__ = [
     'MS_SSIM', 'SWD', 'ms_ssim', 'sliced_wasserstein', 'single_gpu_evaluation',
     'single_gpu_online_evaluation', 'PR', 'IS', 'slerp', 'GenerativeEvalHook',
-    'make_metrics_table', 'make_vanilla_dataloader'
+    'make_metrics_table', 'make_vanilla_dataloader', 'GaussianKLD',
+    'gaussian_kld'
 ]

--- a/mmgen/core/evaluation/evaluation.py
+++ b/mmgen/core/evaluation/evaluation.py
@@ -240,7 +240,7 @@ def single_gpu_online_evaluation(model, data_loader, metrics, logger,
     # parameter. To make the model return probabilistic
 
     special_metrics = []
-    probabilistic_metric = []
+    probabilistic_metrics = []
     vanilla_metrics = []
     special_metric_name = ['PPL']
     probabilistic_metric_name = ['GaussianKLD']
@@ -248,7 +248,7 @@ def single_gpu_online_evaluation(model, data_loader, metrics, logger,
         if metric.name in special_metric_name:
             special_metrics.append(metric)
         elif metric.name in probabilistic_metric_name:
-            probabilistic_metric.append(metric)
+            probabilistic_metrics.append(metric)
         else:
             vanilla_metrics.append(metric)
 
@@ -339,7 +339,7 @@ def single_gpu_online_evaluation(model, data_loader, metrics, logger,
         sys.stdout.write('\n')
 
     # feed probabilistic metric
-    for metric in probabilistic_metric:
+    for metric in probabilistic_metrics:
         metric.prepare()
         pbar = mmcv.ProgressBar(len(data_loader))
         # here we assert probabilistic model have reconstruction mode

--- a/mmgen/core/evaluation/evaluation.py
+++ b/mmgen/core/evaluation/evaluation.py
@@ -280,7 +280,7 @@ def single_gpu_online_evaluation(model, data_loader, metrics, logger,
                                    'channels in the first, '
                                    'not % d' % reals.shape[1])
             if reals.shape[1] == 1:
-                reals = torch.cat([reals] * 3, dim=1)
+                reals = reals.repeat(1, 3, 1, 1)
             num_feed = metric.feed(reals, 'reals')
             if num_feed <= 0:
                 break
@@ -342,7 +342,7 @@ def single_gpu_online_evaluation(model, data_loader, metrics, logger,
     for metric in probabilistic_metrics:
         metric.prepare()
         pbar = mmcv.ProgressBar(len(data_loader))
-        # here we assert probabilistic model have reconstruction mode
+        # here we assume probabilistic model have reconstruction mode
         kwargs['mode'] = 'reconstruction'
         for data in data_loader:
             # key for unconditional GAN
@@ -362,7 +362,7 @@ def single_gpu_online_evaluation(model, data_loader, metrics, logger,
                                    'channels in the first, '
                                    'not % d' % reals.shape[1])
             if reals.shape[1] == 1:
-                reals = torch.cat([reals] * 3, dim=1)
+                reals = reals.repeat(1, 3, 1, 1)
 
             prob_dict = model(reals, return_loss=False, **kwargs)
             num_feed = metric.feed(prob_dict, 'reals')

--- a/mmgen/core/evaluation/evaluation.py
+++ b/mmgen/core/evaluation/evaluation.py
@@ -229,17 +229,26 @@ def single_gpu_online_evaluation(model, data_loader, metrics, logger,
             of the metric table include training configuration and ckpt.
         kwargs (dict): Other arguments.
     """
-    # separate metrics into special metrics and vanilla metrics.
+    # separate metrics into special metrics, probabilistic metrics and vanilla
+    # metrics.
     # For vanilla metrics, images are generated in a random way, and are
     # shared by these metrics. For special metrics like 'PPL', images are
     # generated in a metric-special way and not shared between different
     # metrics.
+    # For probabilistic metrics like 'GaussianKLD', they do not
+    # receive images but receive a dict with cooresponding probabilistic
+    # parameter. To make the model return probabilistic
+
     special_metrics = []
+    probabilistic_metric = []
     vanilla_metrics = []
     special_metric_name = ['PPL']
+    probabilistic_metric_name = ['GaussianKLD']
     for metric in metrics:
         if metric.name in special_metric_name:
             special_metrics.append(metric)
+        elif metric.name in probabilistic_metric_name:
+            probabilistic_metric.append(metric)
         else:
             vanilla_metrics.append(metric)
 
@@ -328,6 +337,36 @@ def single_gpu_online_evaluation(model, data_loader, metrics, logger,
 
         # finish the pbar stdout
         sys.stdout.write('\n')
+
+    # feed probabilistic metric
+    for metric in probabilistic_metric:
+        metric.prepare()
+        pbar = mmcv.ProgressBar(len(data_loader))
+        # here we assert probabilistic model have reconstruction mode
+        kwargs['mode'] = 'reconstruction'
+        for data in data_loader:
+            # key for unconditional GAN
+            if 'real_img' in data:
+                reals = data['real_img']
+            # key for conditional GAN
+            elif 'img' in data:
+                reals = data['img']
+            else:
+                raise KeyError('Cannot found key for images in data_dict. '
+                               'Only support `real_img` for unconditional '
+                               'datasets and `img` for conditional '
+                               'datasets.')
+
+            if reals.shape[1] not in [1, 3]:
+                raise RuntimeError('real images should have one or three '
+                                   'channels in the first, '
+                                   'not % d' % reals.shape[1])
+            if reals.shape[1] == 1:
+                reals = torch.cat([reals] * 3, dim=1)
+
+            prob_dict = model(reals, return_loss=False, **kwargs)
+            num_feed = metric.feed(prob_dict, 'reals')
+            pbar.update(num_feed)
 
     for metric in metrics:
         metric.summary()

--- a/mmgen/models/losses/__init__.py
+++ b/mmgen/models/losses/__init__.py
@@ -5,10 +5,11 @@ from .disc_auxiliary_loss import (DiscShiftLoss, GradientPenaltyLoss,
                                   r1_gradient_penalty_loss)
 from .gan_loss import GANLoss
 from .gen_auxiliary_loss import GeneratorPathRegularizer, gen_path_regularizer
-from .pixelwise_loss import L1Loss, MSELoss
+from .pixelwise_loss import L1Loss, MSELoss, gaussian_kld
 
 __all__ = [
     'GANLoss', 'DiscShiftLoss', 'disc_shift_loss', 'gradient_penalty_loss',
     'GradientPenaltyLoss', 'R1GradientPenalty', 'r1_gradient_penalty_loss',
-    'GeneratorPathRegularizer', 'gen_path_regularizer', 'MSELoss', 'L1Loss'
+    'GeneratorPathRegularizer', 'gen_path_regularizer', 'MSELoss', 'L1Loss',
+    'gaussian_kld'
 ]

--- a/mmgen/models/losses/utils.py
+++ b/mmgen/models/losses/utils.py
@@ -9,11 +9,14 @@ def reduce_loss(loss, reduction):
 
     Args:
         loss (Tensor): Elementwise loss tensor.
-        reduction (str): Options are "none", "mean" and "sum".
+        reduction (str): Options are "none", "mean", "sum" and "batchmean".
 
     Return:
         Tensor: Reduced loss tensor.
     """
+    if reduction == 'batchmean':
+        return loss.sum() / loss.shape[0]
+
     reduction_enum = F._Reduction.get_enum(reduction)
     # none: 0, elementwise_mean:1, sum: 2
     if reduction_enum == 0:

--- a/tests/test_cores/test_metrics.py
+++ b/tests/test_cores/test_metrics.py
@@ -272,8 +272,8 @@ def test_kld_gaussian():
     tar_shape = [2, 3, 4, 4]
     mean1, mean2 = torch.rand(*tar_shape, 1), torch.rand(*tar_shape, 1)
     # var1, var2 = torch.rand(2, 3, 4, 4, 1), torch.rand(2, 3, 4, 4, 1)
-    var1 = torch.randint(1, 3, (*tar_shape, 1))
-    var2 = torch.randint(1, 3, (*tar_shape, 1))
+    var1 = torch.randint(1, 3, (*tar_shape, 1)).float()
+    var2 = torch.randint(1, 3, (*tar_shape, 1)).float()
 
     def pdf(x, mean, var):
         return (1 / np.sqrt(2 * np.pi * var) * torch.exp(-(x - mean)**2 /

--- a/tests/test_cores/test_metrics.py
+++ b/tests/test_cores/test_metrics.py
@@ -66,69 +66,6 @@ def test_ms_ssim():
     assert ssim_result < 1
 
 
-def test_kld_gaussian():
-    # we only test at bz = 1 to test the numerical accuracy
-    # due to the time and memory cost
-    tar_shape = [2, 3, 4, 4]
-    mean1, mean2 = torch.rand(*tar_shape, 1), torch.rand(*tar_shape, 1)
-    # var1, var2 = torch.rand(2, 3, 4, 4, 1), torch.rand(2, 3, 4, 4, 1)
-    var1 = torch.randint(1, 3, (*tar_shape, 1))
-    var2 = torch.randint(1, 3, (*tar_shape, 1))
-
-    def pdf(x, mean, var):
-        return (1 / np.sqrt(2 * np.pi * var) * torch.exp(-(x - mean)**2 /
-                                                         (2 * var)))
-
-    delta = 0.0001
-    indice = torch.arange(-5, 5, delta).repeat(*mean1.shape)
-    p = pdf(indice, mean1, var1)  # pdf of target distribution
-    q = pdf(indice, mean2, var2)  # pdf of predicted distribution
-
-    kld_manually = (p * torch.log(p / q) * delta).sum(dim=(1, 2, 3, 4)).mean()
-
-    data = dict(
-        mean_pred=mean2,
-        mean_target=mean1,
-        logvar_pred=torch.log(var2),
-        logvar_target=torch.log(var1))
-
-    metric = GaussianKLD(2)
-    metric.prepare()
-    metric.feed(data, 'reals')
-    kld = metric.summary()
-    # this is a quite loose limitation for we cannot choose delta which is
-    # small enough for precise kld calculation
-    np.testing.assert_almost_equal(kld, kld_manually, decimal=1)
-    # assert (kld - kld_manually < 1e-1).all()
-
-    metric_base_2 = GaussianKLD(2, log_base='2')
-    metric_base_2.prepare()
-    metric_base_2.feed(data, 'reals')
-    kld_base_2 = metric_base_2.summary()
-    np.testing.assert_almost_equal(kld_base_2, kld / np.log(2), decimal=4)
-    # assert kld_base_2 == kld / np.log(2)
-
-    # test wrong log_base
-    with pytest.raises(AssertionError):
-        GaussianKLD(2, log_base='10')
-
-    # test other reduction --> mean
-    metric = GaussianKLD(2, reduction='mean')
-    metric.prepare()
-    metric.feed(data, 'reals')
-    kld = metric.summary()
-
-    # test other reduction --> sum
-    metric = GaussianKLD(2, reduction='sum')
-    metric.prepare()
-    metric.feed(data, 'reals')
-    kld = metric.summary()
-
-    # test other reduction --> error
-    with pytest.raises(AssertionError):
-        metric = GaussianKLD(2, reduction='none')
-
-
 class TestExtractInceptionFeat:
 
     @classmethod
@@ -162,9 +99,8 @@ class TestExtractInceptionFeat:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason='requires cuda')
     def test_extr_inception_feat_cuda(self):
-        # inception = torch.nn.DataParallel(self.inception)
-        feat = extract_inception_features(self.data_loader,
-                                          self.inception.cuda(), 5)
+        inception = torch.nn.DataParallel(self.inception)
+        feat = extract_inception_features(self.data_loader, inception, 5)
         assert feat.shape[0] == 5
 
     @torch.no_grad()
@@ -178,8 +114,8 @@ class TestExtractInceptionFeat:
         # Tero implementation
         net = torch.jit.load(
             './work_dirs/cache/inception-2015-12-05.pt').eval().cuda()
-        # net = torch.nn.DataParallel(net)
-        feature_tero = net(img.cuda(), return_features=True)
+        net = torch.nn.DataParallel(net)
+        feature_tero = net(img, return_features=True)
 
         print(feature_ours.shape)
 
@@ -328,3 +264,66 @@ class TestPPL:
             ppl.feed(b, 'fakes')
         score = ppl.summary()
         assert score >= 0
+
+
+def test_kld_gaussian():
+    # we only test at bz = 1 to test the numerical accuracy
+    # due to the time and memory cost
+    tar_shape = [2, 3, 4, 4]
+    mean1, mean2 = torch.rand(*tar_shape, 1), torch.rand(*tar_shape, 1)
+    # var1, var2 = torch.rand(2, 3, 4, 4, 1), torch.rand(2, 3, 4, 4, 1)
+    var1 = torch.randint(1, 3, (*tar_shape, 1))
+    var2 = torch.randint(1, 3, (*tar_shape, 1))
+
+    def pdf(x, mean, var):
+        return (1 / np.sqrt(2 * np.pi * var) * torch.exp(-(x - mean)**2 /
+                                                         (2 * var)))
+
+    delta = 0.0001
+    indice = torch.arange(-5, 5, delta).repeat(*mean1.shape)
+    p = pdf(indice, mean1, var1)  # pdf of target distribution
+    q = pdf(indice, mean2, var2)  # pdf of predicted distribution
+
+    kld_manually = (p * torch.log(p / q) * delta).sum(dim=(1, 2, 3, 4)).mean()
+
+    data = dict(
+        mean_pred=mean2,
+        mean_target=mean1,
+        logvar_pred=torch.log(var2),
+        logvar_target=torch.log(var1))
+
+    metric = GaussianKLD(2)
+    metric.prepare()
+    metric.feed(data, 'reals')
+    kld = metric.summary()
+    # this is a quite loose limitation for we cannot choose delta which is
+    # small enough for precise kld calculation
+    np.testing.assert_almost_equal(kld, kld_manually, decimal=1)
+    # assert (kld - kld_manually < 1e-1).all()
+
+    metric_base_2 = GaussianKLD(2, base='2')
+    metric_base_2.prepare()
+    metric_base_2.feed(data, 'reals')
+    kld_base_2 = metric_base_2.summary()
+    np.testing.assert_almost_equal(kld_base_2, kld / np.log(2), decimal=4)
+    # assert kld_base_2 == kld / np.log(2)
+
+    # test wrong log_base
+    with pytest.raises(AssertionError):
+        GaussianKLD(2, base='10')
+
+    # test other reduction --> mean
+    metric = GaussianKLD(2, reduction='mean')
+    metric.prepare()
+    metric.feed(data, 'reals')
+    kld = metric.summary()
+
+    # test other reduction --> sum
+    metric = GaussianKLD(2, reduction='sum')
+    metric.prepare()
+    metric.feed(data, 'reals')
+    kld = metric.summary()
+
+    # test other reduction --> error
+    with pytest.raises(AssertionError):
+        metric = GaussianKLD(2, reduction='none')


### PR DESCRIPTION
# Metric Design
Different from gan metrics, probabilistic metrics:
1. calculated with reconstruction tasks, and can 
2. calculated by a group of parameters but not fake and real images

Therefore, we design a list called `probabilistic_metric_name` to contain probabilistic metrics in `single_gpu_online_evaluation` . When evaluation with those metric separately.

When evaluating those probabilistic metrics, we use set forward mode as **reconstruction**.
We default that all **probabilistic model**  all support this mode. Unlike `forward_test`  which starts with random noise, `mode=reconstruction` performs a reconstruction behavior with given data and returns a dict containing desired probabilistic parameters.

We also slightly modify the batch truncation operation to make the `Metric.feed` support dict input.

## Some further design about `mode=reconstruction`
Although we have not implemented any code, we find a specific function to release reconstruction operation is critical for probabilistic models (e.g., DDPM).
In `train_step`, reconstruction, loss calculation, and update operation are performed altogether.
For `forward_test`, the interface is fixed and called by `sample_from_noise` to perform a random generation process.
Therefore, we need a function to implement a  separate reconstruction process and return all the intermedia probabilistic parameters. And this function can also be called by `train_step`.