### PR TITLE
[Fix] Fix latex rendering in README files.

### DIFF
--- a/configs/biggan/README.md
+++ b/configs/biggan/README.md
@@ -4,16 +4,18 @@
 
 <details>
 <summary align="right"><a href="https://openreview.net/forum?id=B1xsqj09Fm">BigGAN (ICLR'2019)</a></summary>
+
 ```latex
 @inproceedings{
-brock2018large,
-title={Large Scale {GAN} Training for High Fidelity Natural Image Synthesis},
-author={Andrew Brock and Jeff Donahue and Karen Simonyan},
-booktitle={International Conference on Learning Representations},
-year={2019},
-url={https://openreview.net/forum?id=B1xsqj09Fm},
+    brock2018large,
+    title={Large Scale {GAN} Training for High Fidelity Natural Image Synthesis},
+    author={Andrew Brock and Jeff Donahue and Karen Simonyan},
+    booktitle={International Conference on Learning Representations},
+    year={2019},
+    url={https://openreview.net/forum?id=B1xsqj09Fm},
 }
 ```
+
 </details>
 
 The `BigGAN/BigGAN-Deep` is a conditional generation model that can generate both high-resolution and high-quality images by scaling up the batch size and the number of model parameters.

--- a/configs/pggan/README.md
+++ b/configs/pggan/README.md
@@ -5,6 +5,7 @@
 
 <details>
 <summary align="right"><a href="https://arxiv.org/abs/1710.10196">PGGAN (arXiv'2017)</a></summary>
+
 ```latex
 @article{karras2017progressive,
   title={Progressive growing of gans for improved quality, stability, and variation},
@@ -14,12 +15,14 @@
   url={https://arxiv.org/abs/1710.10196},
 }
 ```
+
+</details>
+
 <div align="center">
   <b> Results (compressed) from our PGGAN trained in CelebA-HQ@1024</b>
   <br/>
   <img src="https://user-images.githubusercontent.com/12726765/114009864-1df45400-9896-11eb-9d25-da9eabfe02ce.png" width="800"/>
 </div>
-</details>
 
 ## Results and models
 

--- a/configs/sagan/README.md
+++ b/configs/sagan/README.md
@@ -5,6 +5,7 @@
 
 <details>
 <summary align="right"><a href="https://proceedings.mlr.press/v97/zhang19d.html">SAGAN (ICML'2019)</a></summary>
+
 ```latex
 @inproceedings{zhang2019self,
   title={Self-attention generative adversarial networks},
@@ -16,14 +17,14 @@
   url={https://proceedings.mlr.press/v97/zhang19d.html},
 }
 ```
+
+</details>
+
 <div align="center">
   <b> Results from our SAGAN trained in CIFAR10</b>
   <br/>
   <img src="https://user-images.githubusercontent.com/28132635/127619657-67f2e62d-52e4-43d2-931f-6d0e6e019813.png" width="400"/>
 </div>
-
-</details>
-
 
 ## Results and models
 

--- a/configs/sngan_proj/README.md
+++ b/configs/sngan_proj/README.md
@@ -5,6 +5,7 @@
 
 <details>
 <summary align="right"><a href="https://openreview.net/forum?id=B1QRgziT-">SNGAN (ICLR'2018)</a></summary>
+
 ```latex
 @inproceedings{miyato2018spectral,
   title={Spectral Normalization for Generative Adversarial Networks},
@@ -14,6 +15,9 @@
   url={https://openreview.net/forum?id=B1QRgziT-},
 }
 ```
+
+</details>
+
 <div align="center">
   <b> Results from our SNGAN-PROJ trained in CIFAR10 and ImageNet</b>
   <br/>

--- a/configs/styleganv1/README.md
+++ b/configs/styleganv1/README.md
@@ -5,6 +5,7 @@
 
 <details>
 <summary align="right"><a href="https://openaccess.thecvf.com/content_CVPR_2019/html/Karras_A_Style-Based_Generator_Architecture_for_Generative_Adversarial_Networks_CVPR_2019_paper.html">StyleGANv1 (CVPR'2019)</a></summary>
+
 ```latex
 @inproceedings{karras2019style,
   title={A style-based generator architecture for generative adversarial networks},
@@ -15,6 +16,7 @@
   url={https://openaccess.thecvf.com/content_CVPR_2019/html/Karras_A_Style-Based_Generator_Architecture_for_Generative_Adversarial_Networks_CVPR_2019_paper.html},
 }
 ```
+
 </details>
 
 ## Results and Models

--- a/configs/styleganv2/README.md
+++ b/configs/styleganv2/README.md
@@ -5,6 +5,7 @@
 
 <details>
 <summary align="right"><a href="https://openaccess.thecvf.com/content_CVPR_2020/html/Karras_Analyzing_and_Improving_the_Image_Quality_of_StyleGAN_CVPR_2020_paper.html">StyleGANv2 (CVPR'2020)</a></summary>
+
 ```latex
 @inproceedings{karras2020analyzing,
   title={Analyzing and improving the image quality of stylegan},
@@ -15,6 +16,7 @@
   url={https://openaccess.thecvf.com/content_CVPR_2020/html/Karras_Analyzing_and_Improving_the_Image_Quality_of_StyleGAN_CVPR_2020_paper.html},
 }
 ```
+
 </details>
 
 ## Results and Models


### PR DESCRIPTION
Add blank line before `"```"`  symbol.