### PR TITLE
[Fix] Fix bug of 'resize' when -1 in 'scale'

### DIFF
--- a/tests/test_datasets/test_pipelines/test_augmentation.py
+++ b/tests/test_datasets/test_pipelines/test_augmentation.py
@@ -174,7 +174,10 @@ class TestAugmentations(object):
         assert resize_results['alpha'].shape == (192, 192, 1)
 
         resize = Resize(['gt_img'], (-1, 200))
+        results = dict(gt_img=self.results['gt'].copy())
+        resize_results = resize(results)
         assert resize.scale == (np.inf, 200)
+        assert resize_results['gt_img'].shape == (400, 200, 3)
 
         results = dict(gt_img=self.results['img'].copy())
         resize_keep_ratio = Resize(['gt_img'], scale=0.5, keep_ratio=True)

--- a/tests/test_datasets/test_pipelines/test_augmentation.py
+++ b/tests/test_datasets/test_pipelines/test_augmentation.py
@@ -179,6 +179,12 @@ class TestAugmentations(object):
         assert resize.scale == (np.inf, 200)
         assert resize_results['gt_img'].shape == (400, 200, 3)
 
+        resize = Resize(['gt_img'], (-1, 200))
+        results = dict(gt_img=self.results['gt'].copy().transpose(1, 0, 2))
+        resize_results = resize(results)
+        assert resize.scale == (np.inf, 200)
+        assert resize_results['gt_img'].shape == (200, 400, 3)
+
         results = dict(gt_img=self.results['img'].copy())
         resize_keep_ratio = Resize(['gt_img'], scale=0.5, keep_ratio=True)
         results = resize_keep_ratio(results)


### PR DESCRIPTION
Totally fix two bugs:
1. Error when `-1` in `scale`.
2. `self.scale` and `self.size_factor` can be changed in each sample's resize process and may influence the resize behavior for the following samples.