### PR TITLE
bug fix: concat along the batch dimension

### DIFF
--- a/mmgen/core/hooks/visualization.py
+++ b/mmgen/core/hooks/visualization.py
@@ -70,7 +70,7 @@ class VisualizationHook(Hook):
 
         # img_list = [x for k, x in results.items() if k in self.res_name_list]
         img_list = [results[k] for k in self.res_name_list if k in results]
-        img_cat = torch.cat(img_list, dim=3).detach()
+        img_cat = torch.cat(img_list, dim=0).detach()
         if self.rerange:
             img_cat = ((img_cat + 1) / 2)
         if self.bgr2rgb:


### PR DESCRIPTION
concat the `img_list` along the batch dimension for better visualization when the number of images is more than 4.