### PR TITLE
Fix issue #242

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -182,7 +182,7 @@ def main():
     datasets = [build_dataset(cfg.data.train)]
     if len(cfg.workflow) == 2:
         val_dataset = copy.deepcopy(cfg.data.val)
-        val_dataset.pipeline = cfg.data.train.pipeline
+        val_dataset.pipeline = cfg.data.val.pipeline
         datasets.append(build_dataset(val_dataset))
     if cfg.checkpoint_config is not None:
         # save mmgen version, config file content and class names in


### PR DESCRIPTION
The validation pipeline should be loaded from `cfg.data.val`, but it is currently loading from  `cfg.data.train`