### PR TITLE
[Fix] fix ddpm sampler under win10

### DIFF
--- a/mmgen/models/diffusions/sampler.py
+++ b/mmgen/models/diffusions/sampler.py
@@ -30,7 +30,7 @@ class UniformTimeStepSampler:
         # official ones.
         return torch.from_numpy(
             np.random.choice(
-                self.num_timesteps, size=(batch_size, ), p=self.prob))
+                self.num_timesteps, size=(batch_size, ), p=self.prob)).long()
 
     def __call__(self, batch_size):
         """Return sampled results."""


### PR DESCRIPTION
The return type of `numpy.random.choice` is different under Windows and Linux.
Add a force type convention after sampling.