### PR TITLE
[Feature] support pass s3 training kwargs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  ruby: 2.7.3
 repos:
   - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.8.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  ruby: 2.7.3
 repos:
   - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.8.3

--- a/mmgen/models/architectures/stylegan/generator_discriminator_v3.py
+++ b/mmgen/models/architectures/stylegan/generator_discriminator_v3.py
@@ -178,3 +178,20 @@ class StyleGANv3Generator(nn.Module):
         if hasattr(self.style_mapping, 'w_avg'):
             return self.style_mapping.w_avg
         return get_mean_latent(self, num_samples, **kwargs)
+
+    def get_training_kwargs(self, phase):
+        """Get training kwargs. In StyleGANv3, we enable fp16, and update
+        mangitude ema during training of discriminator. This function is used
+        to pass related arguments.
+
+        Args:
+            phase (str): Current training phase.
+
+        Returns:
+            dict: Training kwargs.
+        """
+        if phase == 'disc':
+            return dict(update_emas=True, force_fp32=False)
+        if phase == 'gen':
+            return dict(force_fp32=False)
+        return {}

--- a/mmgen/models/gans/static_unconditional_gan.py
+++ b/mmgen/models/gans/static_unconditional_gan.py
@@ -167,8 +167,16 @@ class StaticUnconditionalGAN(BaseGAN):
         set_requires_grad(self.discriminator, True)
         optimizer['discriminator'].zero_grad()
         # TODO: add noise sampler to customize noise sampling
+
+        # pass model specific training kwargs
+        g_training_kwargs = {}
+        if hasattr(self.generator, 'get_training_kwargs'):
+            g_training_kwargs.update(
+                self.generator.get_training_kwargs(phase='disc'))
+
         with torch.no_grad():
-            fake_imgs = self.generator(None, num_batches=batch_size)
+            fake_imgs = self.generator(
+                None, num_batches=batch_size, **g_training_kwargs)
 
         # disc pred for fake imgs and real_imgs
         disc_pred_fake = self.discriminator(fake_imgs)
@@ -231,7 +239,15 @@ class StaticUnconditionalGAN(BaseGAN):
         optimizer['generator'].zero_grad()
 
         # TODO: add noise sampler to customize noise sampling
-        fake_imgs = self.generator(None, num_batches=batch_size)
+
+        # pass model specific training kwargs
+        g_training_kwargs = {}
+        if hasattr(self.generator, 'get_training_kwargs'):
+            g_training_kwargs.update(
+                self.generator.get_training_kwargs(phase='gen'))
+
+        fake_imgs = self.generator(
+            None, num_batches=batch_size, **g_training_kwargs)
         disc_pred_fake_g = self.discriminator(fake_imgs)
 
         data_dict_ = dict(

--- a/tests/test_models/test_static_unconditional_gan.py
+++ b/tests/test_models/test_static_unconditional_gan.py
@@ -180,11 +180,11 @@ class TestStaticUnconditionalGAN(object):
             type='StaticUnconditionalGAN',
             generator=dict(
                 type='StyleGANv3Generator',
-                out_size=32,
+                out_size=16,
                 style_channels=8,
                 img_channels=3,
                 synthesis_cfg=synthesis_cfg),
-            discriminator=dict(type='StyleGAN2Discriminator', in_size=32),
+            discriminator=dict(type='StyleGAN2Discriminator', in_size=16),
             gan_loss=dict(type='GANLoss', gan_type='wgan-logistic-ns'))
 
         s3gan = build_model(default_config)
@@ -197,16 +197,13 @@ class TestStaticUnconditionalGAN(object):
             _ = s3gan(None, return_loss=True)
         # test forward test
         imgs = s3gan(None, return_loss=False, mode='sampling', num_batches=2)
-        assert imgs.shape == (2, 3, 32, 32)
+        assert imgs.shape == (2, 3, 16, 16)
 
         # test train step
-        data = torch.randn((2, 3, 32, 32))
+        data = torch.randn((2, 3, 16, 16))
         data_input = dict(real_img=data)
         optimizer_g = torch.optim.SGD(s3gan.generator.parameters(), lr=0.01)
         optimizer_d = torch.optim.SGD(
             s3gan.discriminator.parameters(), lr=0.01)
         optim_dict = dict(generator=optimizer_g, discriminator=optimizer_d)
-
-        _ = s3gan.train_step(
-            data_input, optim_dict, running_status=dict(iteration=1))
         _ = s3gan.train_step(data_input, optim_dict)

--- a/tests/test_models/test_static_unconditional_gan.py
+++ b/tests/test_models/test_static_unconditional_gan.py
@@ -169,8 +169,7 @@ class TestStaticUnconditionalGAN(object):
         assert 'loss_disc_fake' in model_outputs['log_vars']
         assert 'loss_disc_fake_g' in model_outputs['log_vars']
 
-    @pytest.mark.skipif(
-        torch.__version__ in ['1.5.1', '1.7.0'], reason='avoid killing')
+    @pytest.mark.skipif(torch.__version__ in ['1.5.1'], reason='avoid killing')
     def test_pass_training_kwargs_cpu(self):
         synthesis_cfg = {
             'type': 'SynthesisNetwork',

--- a/tests/test_models/test_static_unconditional_gan.py
+++ b/tests/test_models/test_static_unconditional_gan.py
@@ -169,22 +169,24 @@ class TestStaticUnconditionalGAN(object):
         assert 'loss_disc_fake' in model_outputs['log_vars']
         assert 'loss_disc_fake_g' in model_outputs['log_vars']
 
+    @pytest.mark.skipif(
+        torch.__version__ in ['1.5.1', '1.7.0'], reason='avoid killing')
     def test_pass_training_kwargs_cpu(self):
         synthesis_cfg = {
             'type': 'SynthesisNetwork',
-            'channel_base': 32768,
-            'channel_max': 512,
+            'channel_base': 1024,
+            'channel_max': 16,
             'magnitude_ema_beta': 0.999
         }
         default_config = dict(
             type='StaticUnconditionalGAN',
             generator=dict(
                 type='StyleGANv3Generator',
-                out_size=16,
+                out_size=8,
                 style_channels=8,
                 img_channels=3,
                 synthesis_cfg=synthesis_cfg),
-            discriminator=dict(type='StyleGAN2Discriminator', in_size=16),
+            discriminator=dict(type='StyleGAN2Discriminator', in_size=8),
             gan_loss=dict(type='GANLoss', gan_type='wgan-logistic-ns'))
 
         s3gan = build_model(default_config)
@@ -197,10 +199,10 @@ class TestStaticUnconditionalGAN(object):
             _ = s3gan(None, return_loss=True)
         # test forward test
         imgs = s3gan(None, return_loss=False, mode='sampling', num_batches=2)
-        assert imgs.shape == (2, 3, 16, 16)
+        assert imgs.shape == (2, 3, 8, 8)
 
         # test train step
-        data = torch.randn((2, 3, 16, 16))
+        data = torch.randn((2, 3, 8, 8))
         data_input = dict(real_img=data)
         optimizer_g = torch.optim.SGD(s3gan.generator.parameters(), lr=0.01)
         optimizer_d = torch.optim.SGD(


### PR DESCRIPTION
In StyleGANv3, we need to set `force_fp32` to False during training and set `updates_ema` to True during disc training.
I tackle this by adding an extra function to pass kwargs in s3 generator.