### PR TITLE
Fixed a bug in building valid dataloader

### DIFF
--- a/mmgen/apis/train.py
+++ b/mmgen/apis/train.py
@@ -179,8 +179,7 @@ def train_model(model,
             **loader_cfg, 'shuffle': False,
             **cfg.data.get('val_data_loader', {})
         }
-        val_dataloader = build_dataloader(
-            val_dataset, dist=distributed, **val_loader_cfg)
+        val_dataloader = build_dataloader(val_dataset, **val_loader_cfg)
         eval_cfg = deepcopy(cfg.get('evaluation'))
         priority = eval_cfg.pop('priority', 'LOW')
         eval_cfg.update(dict(dist=distributed, dataloader=val_dataloader))


### PR DESCRIPTION
When I ran my training scripts on your newest commit [2a79796], there is a type error in `mmgen/apis/train.py` :
```
build_dataloader() got multiple values for keyword argument 'dist'
  File "~/mmgeneration/mmgen/apis/train.py", line 182, in train_model
    val_dataloader = build_dataloader(
  File "~/mmgeneration/tools/train.py", line 217, in main
    train_model(
  File "~/mmgeneration/tools/train.py", line 228, in <module>
    main()
```
Seems there are redundant `dist=distributed` and I removed it.