### PR TITLE
Switch from opencv-python to opencv-python-headless 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Upgrade pip
         run: pip install pip --upgrade --user
       - name: Install OpenCV
-        run: pip install opencv-python>=3
+        run: pip install opencv-python-headless>=3
       - name: Install PyTorch
         # As a complement to Linux CI, we test on PyTorch LTS version
         run: pip install torch==1.8.2+${{ matrix.platform }} torchvision==0.9.2+${{ matrix.platform }} -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html


### PR DESCRIPTION
opencv-python-headless is package for server (headless) environments.