### PR TITLE
[Fix] revise pip upgrade for win-ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Upgrade pip
-        run: pip install pip --upgrade --user
+        run: python -m pip install pip --upgrade --user
       - name: Install OpenCV
         run: pip install opencv-python>=3
       - name: Install PyTorch


### PR DESCRIPTION
`pip install --upgrade pip` is failing on windows GitHub actions runners with v22.0.