### PR TITLE
[Fix] Fix PrecisionAndRecall metric

### DIFF
--- a/mmgen/core/evaluation/metric_utils.py
+++ b/mmgen/core/evaluation/metric_utils.py
@@ -225,8 +225,8 @@ def finalize_descriptors(desc):
 
 def compute_pr_distances(row_features,
                          col_features,
-                         num_gpus,
-                         rank,
+                         num_gpus=1,
+                         rank=0,
                          col_batch_size=10000):
     r"""Compute distances between real images and fake images.
 


### PR DESCRIPTION
Since compute_metrics is only performed on main process, we directly set `rank`=0 and `num_gpus`=1 in compute_pr_metric function.