### PR TITLE
[Fix] Limit mmcls version and remove unneeded meta keys in test_dataloader of pix2pix

### DIFF
--- a/configs/pix2pix/pix2pix_vanilla_unet_bn_aerial2maps_b1x1_220k.py
+++ b/configs/pix2pix/pix2pix_vanilla_unet_bn_aerial2maps_b1x1_220k.py
@@ -67,12 +67,7 @@ test_pipeline = [
         ]),
     dict(
         type='PackGenInputs',
-        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'],
-        meta_keys=[
-            'pair_path', 'sample_idx', 'pair_ori_shape',
-            f'img_{domain_a}_path', f'img_{domain_b}_path',
-            f'img_{domain_a}_ori_shape', f'img_{domain_b}_ori_shape'
-        ])
+        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'])
 ]
 dataroot = 'data/pix2pix/maps'
 train_dataloader = dict(

--- a/configs/pix2pix/pix2pix_vanilla_unet_bn_aerial2maps_b1x1_220k.py
+++ b/configs/pix2pix/pix2pix_vanilla_unet_bn_aerial2maps_b1x1_220k.py
@@ -67,7 +67,8 @@ test_pipeline = [
         ]),
     dict(
         type='PackGenInputs',
-        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'])
+        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'],
+        meta_keys=[f'img_{domain_a}_path', f'img_{domain_b}_path'])
 ]
 dataroot = 'data/pix2pix/maps'
 train_dataloader = dict(

--- a/configs/pix2pix/pix2pix_vanilla_unet_bn_facades_b1x1_80k.py
+++ b/configs/pix2pix/pix2pix_vanilla_unet_bn_facades_b1x1_80k.py
@@ -68,7 +68,8 @@ test_pipeline = [
         ]),
     dict(
         type='PackGenInputs',
-        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'])
+        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'],
+        meta_keys=[f'img_{domain_a}_path', f'img_{domain_b}_path'])
 ]
 
 dataroot = 'data/pix2pix/facades'

--- a/configs/pix2pix/pix2pix_vanilla_unet_bn_maps2aerial_b1x1_220k.py
+++ b/configs/pix2pix/pix2pix_vanilla_unet_bn_maps2aerial_b1x1_220k.py
@@ -68,12 +68,7 @@ test_pipeline = [
         ]),
     dict(
         type='PackGenInputs',
-        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'],
-        meta_keys=[
-            'pair_path', 'sample_idx', 'pair_ori_shape',
-            f'img_{domain_a}_path', f'img_{domain_b}_path',
-            f'img_{domain_a}_ori_shape', f'img_{domain_b}_ori_shape'
-        ])
+        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'])
 ]
 
 dataroot = 'data/pix2pix/maps'

--- a/configs/pix2pix/pix2pix_vanilla_unet_bn_maps2aerial_b1x1_220k.py
+++ b/configs/pix2pix/pix2pix_vanilla_unet_bn_maps2aerial_b1x1_220k.py
@@ -68,7 +68,8 @@ test_pipeline = [
         ]),
     dict(
         type='PackGenInputs',
-        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'])
+        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'],
+        meta_keys=[f'img_{domain_a}_path', f'img_{domain_b}_path'])
 ]
 
 dataroot = 'data/pix2pix/maps'

--- a/configs/pix2pix/pix2pix_vanilla_unet_bn_wo_jitter_flip_edges2shoes_b1x4_190k.py
+++ b/configs/pix2pix/pix2pix_vanilla_unet_bn_wo_jitter_flip_edges2shoes_b1x4_190k.py
@@ -67,12 +67,7 @@ test_pipeline = [
         ]),
     dict(
         type='PackGenInputs',
-        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'],
-        meta_keys=[
-            'pair_path', 'sample_idx', 'pair_ori_shape',
-            f'img_{domain_a}_path', f'img_{domain_b}_path',
-            f'img_{domain_a}_ori_shape', f'img_{domain_b}_ori_shape'
-        ])
+        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'])
 ]
 
 dataroot = './data/pix2pix/edges2shoes'

--- a/configs/pix2pix/pix2pix_vanilla_unet_bn_wo_jitter_flip_edges2shoes_b1x4_190k.py
+++ b/configs/pix2pix/pix2pix_vanilla_unet_bn_wo_jitter_flip_edges2shoes_b1x4_190k.py
@@ -67,7 +67,8 @@ test_pipeline = [
         ]),
     dict(
         type='PackGenInputs',
-        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'])
+        keys=[f'img_{domain_a}', f'img_{domain_b}', 'pair'],
+        meta_keys=[f'img_{domain_a}_path', f'img_{domain_b}_path'])
 ]
 
 dataroot = './data/pix2pix/edges2shoes'

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,4 @@
-mmcls
+mmcls>=1.0.0rc0
 ninja
 numpy
 prettytable


### PR DESCRIPTION
1. Set mmcls>=1.0.0rc0
2. Remove sample_idx and other unneed meta keys in `test_dataloader` of pix2pix.