### PR TITLE
Fix type error in stylegan3 config and metrics in lsgan config

### DIFF
--- a/configs/lsgan/lsgan_dcgan-archi_lr-1e-4_lsun-bedroom_64_b128x1_12m.py
+++ b/configs/lsgan/lsgan_dcgan-archi_lr-1e-4_lsun-bedroom_64_b128x1_12m.py
@@ -17,10 +17,10 @@ data_root = './data/lsun/bedroom_train'
 train_dataloader = dict(
     batch_size=batch_size, dataset=dict(data_root=data_root))
 
-val_dataloader = dict(batch_size=batch_size, dataset=dict(data_root=data_root))
+test_bs = 32
+val_dataloader = dict(batch_size=test_bs, dataset=dict(data_root=data_root))
 
-test_dataloader = dict(
-    batch_size=batch_size, dataset=dict(data_root=data_root))
+test_dataloader = dict(batch_size=test_bs, dataset=dict(data_root=data_root))
 
 optim_wrapper = dict(
     generator=dict(optimizer=dict(type='Adam', lr=0.0001, betas=(0.5, 0.99))),

--- a/configs/lsgan/lsgan_lsgan-archi_lr-1e-4_lsun-bedroom_128_b64x1_10m.py
+++ b/configs/lsgan/lsgan_lsgan-archi_lr-1e-4_lsun-bedroom_128_b64x1_10m.py
@@ -15,10 +15,10 @@ data_root = './data/lsun/bedroom_train'
 train_dataloader = dict(
     batch_size=batch_size, dataset=dict(data_root=data_root))
 
-val_dataloader = dict(batch_size=batch_size, dataset=dict(data_root=data_root))
+test_bs = 32
+val_dataloader = dict(batch_size=test_bs, dataset=dict(data_root=data_root))
 
-test_dataloader = dict(
-    batch_size=batch_size, dataset=dict(data_root=data_root))
+test_dataloader = dict(batch_size=test_bs, dataset=dict(data_root=data_root))
 
 optim_wrapper = dict(
     generator=dict(optimizer=dict(type='Adam', lr=0.0001, betas=(0.5, 0.99))),

--- a/configs/styleganv3/stylegan3_t_noaug_fp16_gamma32.8_ffhq_1024_b4x8.py
+++ b/configs/styleganv3/stylegan3_t_noaug_fp16_gamma32.8_ffhq_1024_b4x8.py
@@ -24,7 +24,6 @@ ema_config = dict(
     start_iter=0)
 
 model = dict(
-    type='StaticUnconditionalGAN',
     generator=dict(out_size=1024, img_channels=3, synthesis_cfg=synthesis_cfg),
     discriminator=dict(in_size=1024),
     loss_config=dict(r1_loss_weight=r1_gamma / 2.0 * d_reg_interval),


### PR DESCRIPTION
1. Error: type='StaticUnconditionalGAN'.
2. Only use 50k real images for evaluation, not total set.