### PR TITLE
[Fix] fix SiLU activation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,6 @@ repos:
     rev: 0.7.9
     hooks:
       - id: mdformat
-        language_version: python3.7
         args: ["--number", "--table-width", "200"]
         additional_dependencies:
           - mdformat-openmmlab

--- a/mmgen/models/architectures/ddpm/modules.py
+++ b/mmgen/models/architectures/ddpm/modules.py
@@ -32,36 +32,39 @@ class EmbedSequential(nn.Sequential):
         return x
 
 
-@ACTIVATION_LAYERS.register_module()
-class SiLU(nn.Module):
-    r"""Applies the Sigmoid Linear Unit (SiLU) function, element-wise.
-    The SiLU function is also known as the swish function.
-    Args:
-        input (bool, optional): Use inplace operation or not.
-            Defaults to `False`.
-    """
+if digit_version(mmcv.__version__) < digit_version('1.6.2'):
 
-    def __init__(self, inplace=False):
-        super().__init__()
-        if digit_version(
-                torch.__version__) < digit_version('1.7.0') and inplace:
-            mmcv.print_log('Inplace version of \'SiLU\' is not supported for '
-                           f'torch < 1.7.0, found \'{torch.version}\'.')
-        self.inplace = inplace
-
-    def forward(self, x):
-        """Forward function for SiLU.
+    @ACTIVATION_LAYERS.register_module()
+    class SiLU(nn.Module):
+        r"""Applies the Sigmoid Linear Unit (SiLU) function, element-wise.
+        The SiLU function is also known as the swish function.
         Args:
-            x (torch.Tensor): Input tensor.
-
-        Returns:
-            torch.Tensor: Tensor after activation.
+            input (bool, optional): Use inplace operation or not.
+                Defaults to `False`.
         """
 
-        if digit_version(torch.__version__) < digit_version('1.7.0'):
-            return x * torch.sigmoid(x)
+        def __init__(self, inplace=False):
+            super().__init__()
+            if digit_version(
+                    torch.__version__) < digit_version('1.7.0') and inplace:
+                mmcv.print_log('Inplace version of \'SiLU\' is not supported '
+                               'for torch < 1.7.0, found '
+                               f'\'{torch.version}\'.')
+            self.inplace = inplace
 
-        return F.silu(x, inplace=self.inplace)
+        def forward(self, x):
+            """Forward function for SiLU.
+            Args:
+                x (torch.Tensor): Input tensor.
+
+            Returns:
+                torch.Tensor: Tensor after activation.
+            """
+
+            if digit_version(torch.__version__) < digit_version('1.7.0'):
+                return x * torch.sigmoid(x)
+
+            return F.silu(x, inplace=self.inplace)
 
 
 @MODULES.register_module()

--- a/mmgen/models/architectures/ddpm/modules.py
+++ b/mmgen/models/architectures/ddpm/modules.py
@@ -32,7 +32,7 @@ class EmbedSequential(nn.Sequential):
         return x
 
 
-if digit_version(mmcv.__version__) < digit_version('1.6.2'):
+if 'SiLU' not in ACTIVATION_LAYERS:
 
     @ACTIVATION_LAYERS.register_module()
     class SiLU(nn.Module):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

MMCV v 1.6.2 support`SiLU` activation function and registers it to `ACTIVATION_LAYERS`.  This conflict with MMGen's `SiLU` implementation.

## Modification

Only register `SiLU` when MMCV version is lower than 1.6.2

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
