### PR TITLE
fix tensor and index aren't on the same device error

### DIFF
--- a/mmgen/models/architectures/ddpm/denoising.py
+++ b/mmgen/models/architectures/ddpm/denoising.py
@@ -112,9 +112,9 @@ class DenoisingUnet(nn.Module):
         downsample_conv (bool, optional): Whether use conv operation in
             downsample block.  Defaults to ``True``.
         upsample_cfg (dict, optional): Config for upsample blocks.
-            Defaults to ``dict(type='DenoisingDownsample')``.
-        downsample_cfg (dict, optional): Config for downsample blocks.
             Defaults to ``dict(type='DenoisingUpsample')``.
+        downsample_cfg (dict, optional): Config for downsample blocks.
+            Defaults to ``dict(type='DenoisingDownsample')``.
         attention_res (int | list[int], optional): Resolution of feature maps
             to apply attention operation. Defaults to ``[16, 8]``.
         pretrained (str | dict, optional): Path for the pretrained model or

--- a/mmgen/models/diffusions/utils.py
+++ b/mmgen/models/diffusions/utils.py
@@ -258,7 +258,7 @@ def var_to_tensor(var, index, target_shape=None, device=None):
         torch.Tensor: Converted variable.
     """
     # we must move var to cuda for it's ndarray in current design
-    var_indexed = torch.from_numpy(var)[index].float()
+    var_indexed = torch.from_numpy(var)[index.cpu()].float()
 
     if device is not None:
         var_indexed = var_indexed.to(device)


### PR DESCRIPTION
`var_indexed = torch.from_numpy(var)[index].float()` this line will result in an error with `torch==1.13.0+cu117`.
because the tensor `torch.from_numpy(var)` and index `index` may not on the same device.

Change to `var_indexed = torch.from_numpy(var)[index.cpu()].float()` resolves the issue.

## Screenshots
Screenshots after executing `python tools/train.py configs/improved_ddpm/ddpm_cosine_hybird_timestep-4k_drop0.3_cifar10_32x32_b8x16_500k.py`.
### Before modification:
![image](https://user-images.githubusercontent.com/6763078/200390777-b460bcc1-14ff-4988-b71e-24577e208fd2.png)

### After modification
![image](https://user-images.githubusercontent.com/6763078/200390971-cd1bebeb-b26b-47ca-b542-e38c8095e14c.png)
