### PR TITLE
Add missing ' in documentation

### DIFF
--- a/docs/en/tutorials/customize_models.md
+++ b/docs/en/tutorials/customize_models.md
@@ -73,7 +73,7 @@ Only decorating the new class will **NOT** register the new class into our regis
 
 from .new_generators import NewGenerator
 
-__all__ = ['NewGenerator]
+__all__ = ['NewGenerator']
 ```
 
 If you have already import some modules in a `__init__.py` file, the code still meets `cannot import error`, though. You may try to import this module from the parent package's `__init__.py` file.


### PR DESCRIPTION
## Motivation

Fix typo in documentation 

## Modification

I've added a closing ' to the documentation

## Who can help? @ them here!

## Checklist

**Before PR**:

- [x ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) to create this PR.
- [ x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmediting/blob/master/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
